### PR TITLE
fix(popup): address flexbox issue on iOS 10

### DIFF
--- a/packages/popup-component/src/components/popup/popup.scss
+++ b/packages/popup-component/src/components/popup/popup.scss
@@ -95,3 +95,8 @@
     font-size: $font-size-base * 0.375;
   }
 }
+
+.flex-row {
+  display: flex;
+  flex-direction: row;
+}

--- a/packages/popup-component/src/components/popup/popup.tsx
+++ b/packages/popup-component/src/components/popup/popup.tsx
@@ -38,26 +38,26 @@ export class DcPopup {
 
     return (
       <div class="notification" onClick={() => window.open(this.url)}>
-        <div class="notification-col">
-          <div class="notification__title">{this.hero}</div>
-          {this.date ? (
-            <div class="notification__date">Updated {this.date}</div>
-          ) : null}
-        </div>
-        <div class="notification-col">
-          <div class="notification__content">
-            {/* This is used by Stencil to pass HTML to components, just like react's children */}
-            <slot />
+        <div class="flex-row">
+          <div class="notification-col">
+            <div class="notification__title">{this.hero}</div>
+            {this.date ? (
+              <div class="notification__date">Updated {this.date}</div>
+            ) : null}
+            <div class="notification__content">
+              {/* This is used by Stencil to pass HTML to components, just like react's children */}
+              <slot />
+            </div>
           </div>
+          <button
+            type="button"
+            class="close"
+            aria-label="Close"
+            onClick={e => this.close(e)}
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
         </div>
-        <button
-          type="button"
-          class="close"
-          aria-label="Close"
-          onClick={e => this.close(e)}
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
       </div>
     );
   }


### PR DESCRIPTION
**What:**
Allow popup to render properly on webkit browsers for iOS 10

**Why:**

fix https://app.asana.com/0/1168997577035609/1179368978953593

**How:**
Use nested containers as suggested at [StackOverflow topic solution](https://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent) more information about the issue at [StackOverflow topic explanation](https://stackoverflow.com/questions/44878379/why-does-width-and-height-of-a-flex-item-affect-how-a-flex-item-is-rendered) or [official webkit errors](https://bugs.webkit.org/show_bug.cgi?id=136041)

**Media**
[How it looks now](https://user-images.githubusercontent.com/1425162/84669951-bdbaad00-af25-11ea-886e-f94edc9bb6bb.png)
[How it looks before](https://user-images.githubusercontent.com/1425162/84670028-d7f48b00-af25-11ea-95ec-daff6d2b3f06.png)
