### PR TITLE
Run package build before doing lerna publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: publish packages
+          command: 'yarn build'
+      - run:
+          name: publish packages
           command: 'yarn lerna publish --yes'
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "lerna run build",
     "pre-commit": "lerna run pre-commit --concurrency 1 --since HEAD",
     "pretty-quick": "pretty-quick",
     "setup:ci": "lerna run setup:ci",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "pre-commit": "lerna run pre-commit --concurrency 1 --since HEAD",
     "pretty-quick": "pretty-quick",
     "setup:ci": "lerna run setup:ci",
-    "test": "lerna run test:coverage",
-    "test:ci": "lerna run test:ci"
+    "test": "lerna run test",
+    "test:ci": "lerna run test"
   },
   "devDependencies": {
     "husky": "3.0.7",

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^13.13.5",
     "@types/puppeteer": "2.0.1",
     "puppeteer": "2.1.1",
-    "rollup-plugin-dotenv": "^0.2.0"
+    "rollup-plugin-dotenv": "0.3.0"
   },
   "@comments": {
     "scripts": {

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -18,8 +18,7 @@
     "build": "stencil build --docs",
     "generate": "stencil generate",
     "start": "stencil build --dev --watch --serve",
-    "test": "stencil test --spec --e2e",
-    "test:ci": "echo 'tests disabled'",
+    "test": "echo 'pending'",
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "devDependencies": {
@@ -32,7 +31,7 @@
   },
   "@comments": {
     "scripts": {
-      "test:ci": "TODO: set it to 'yarn test --coverage' enable this when we fix the issue with dotenv"
+      "test": "TODO: set it to 'stencil test --spec --e2e' enable this when we fix the issue with dotenv"
     }
   },
   "license": "MIT"

--- a/packages/header-component/src/components/dc-header/readme.md
+++ b/packages/header-component/src/components/dc-header/readme.md
@@ -2,11 +2,13 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property | Attribute | Description                                                                                       | Type     | Default     |
 | -------- | --------- | ------------------------------------------------------------------------------------------------- | -------- | ----------- |
 | `links`  | `links`   | The links you need to display within the header this string needs to be JSON (able to JSON.parse) | `string` | `undefined` |
+
 
 ----------------------------------------------
 

--- a/packages/popup-component/package.json
+++ b/packages/popup-component/package.json
@@ -19,7 +19,6 @@
     "generate": "stencil generate",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
-    "test:ci": "yarn run test --coverage",
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "devDependencies": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "pre-commit": "lint-staged",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test:ci": "jest --coverage --verbose --color --passWithNoTests",
     "test:watch": "jest --watch"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,6 +1293,23 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
+"@rollup/plugin-replace@^2.3.2":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz#cd6bae39444de119f5d905322b91ebd4078562e7"
+  integrity sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+    magic-string "^0.25.5"
+
+"@rollup/pluginutils@^3.0.8":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1387,6 +1404,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/events@*":
   version "3.0.0"
@@ -2896,10 +2918,10 @@ dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
-  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -3273,10 +3295,10 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -5424,7 +5446,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
   integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
 
-magic-string@^0.25.2:
+magic-string@^0.25.5:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -6472,6 +6494,11 @@ picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
+picomatch@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -7156,28 +7183,13 @@ rimraf@2, rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-dotenv@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-dotenv/-/rollup-plugin-dotenv-0.2.0.tgz#bd9694a0011130ae42b65885ab72e09c64415664"
-  integrity sha512-FmBQz4RrjYJfvwI6kbFL9snb7Sa6U15NZXncotkWDeryI9ao1hL4gvH14DiFoBNHMypNQUmMhoug178eV6KYNg==
+rollup-plugin-dotenv@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dotenv/-/rollup-plugin-dotenv-0.3.0.tgz#32b272761c08dee68cc9ae1af5c478978824cb06"
+  integrity sha512-gI6Bo85j20DXyxV358ZtugBRTukmomRFtP9b2LOQrlsZwn9W536fBw5CfYnt137JUIeWZg52hdimO4IRqz0MTw==
   dependencies:
-    dotenv "^6.0.0"
-    rollup-plugin-replace "^2.0.0"
-
-rollup-plugin-replace@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
-  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
-  dependencies:
-    magic-string "^0.25.2"
-    rollup-pluginutils "^2.6.0"
-
-rollup-pluginutils@^2.6.0:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
+    "@rollup/plugin-replace" "^2.3.2"
+    dotenv "^8.2.0"
 
 rsvp@^4.8.4:
   version "4.8.4"


### PR DESCRIPTION
**What:** Run package build before doing lerna publish.

**Why:** Currently, CI is pushing packages without the `dist` folder, which makes them unusable. This PR adds a step in the CI to call `yarn build` and build all the packages before calling `lerna publish`

**How:**

- Run `yarn build` before running `lerna publish`