### PR TITLE
dev: add publishConfig.access public to all packages

### DIFF
--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -14,6 +14,9 @@
     "dist/",
     "loader/"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "stencil build --docs",
     "generate": "stencil generate",

--- a/packages/popup-component/package.json
+++ b/packages/popup-component/package.json
@@ -14,6 +14,9 @@
     "dist/",
     "loader/"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "stencil build --docs",
     "generate": "stencil generate",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,15 +10,15 @@
     "src": "src",
     "test": "__tests__"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "files": [
     "src"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/debtcollective/disputes.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "pre-commit": "lint-staged",


### PR DESCRIPTION
**What:** dev: add publishConfig.access public to all packages

**Why:** This is needed for lerna to publish correctly news org scope packages (ex: @debtcollective/header-component)

**How:**

- add `publishConfig` to package.json