### PR TITLE
Header drop environment variable usage

### DIFF
--- a/packages/header-component/.env.sample
+++ b/packages/header-component/.env.sample
@@ -1,3 +1,0 @@
-# URLs without the lastest '/'
-HOST_URL=http://lvh.me:3333
-COMMUNITY_URL=http://lvh.me:3000

--- a/packages/header-component/README.md
+++ b/packages/header-component/README.md
@@ -14,25 +14,23 @@ Stencil components are just Web Components, so they work in any major framework 
 
 ## Getting Started
 
-For header to have the dynamic variables you need to `cp .env.sample .env` then simple run.
-
 ```bash
-npm install
-npm start
+yarn install
+yarn start
 ```
 
-> In order to have a sense over the community session, you need to have the application running and make sure COMMUNITY_URL variable match the application *(is set to localhost port 3000 by default)*. Ultimately, you will need to allow CORS on the community app in that sense: Admin > Settings > CORS > add `http://lvh.me:3333`
+> In order to have a sense over the community session, you need to have the application running and make sure `community` prop variable match the application, like `http://lvh.me:3000`. Ultimately, you will need to allow CORS on the community app in that sense: Admin > Settings > CORS > add `http://lvh.me:3333` which suppose to be your `host` prop. Check example below.
 
 To build the component for production, run:
 
 ```bash
-npm run build
+yarn build
 ```
 
 To run the unit tests for the components, run:
 
 ```bash
-npm test
+yarn test
 ```
 
 Need help? Check out our docs [here](https://stenciljs.com/docs/my-first-component).
@@ -48,13 +46,13 @@ Instead, use a prefix that fits your company or any name for a group of related 
 You can render the default styles with links you pass as props like:
 
 ```html
-<dc-header links='[{"href":"http://debtcollective.org/","text":"About us"}, {"href":"https://community.debtcollective.org/","text":"Community"}, {"href":"https://teespring.com/stores/debt-collective","text":"Store"}]'></dc-header>
+<dc-header host="http://lvh.me:3333" community="http://lvh.me:3000" links='[{"href":"http://debtcollective.org/","text":"About us"}, {"href":"https://community.debtcollective.org/","text":"Community"}, {"href":"https://teespring.com/stores/debt-collective","text":"Store"}]'></dc-header>
 ```
 
 Alternatively, you can choose to inject your own structure by doing something like:
 
 ```html
-<dc-header>
+<dc-header host="http://lvh.me:3333" community="http://lvh.me:3000">
   <div slot="header">
     <div class="nav-item d-md-flex">
       <a class="nav-link" href='http://debtcollective.org/'>
@@ -71,6 +69,8 @@ Alternatively, you can choose to inject your own structure by doing something li
   </div>
 </dc-header>
 ```
+
+> NOTE: be aware of not adding the latest "/" on the url props such as host and community
 
 ### Script tag
 

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -29,8 +29,7 @@
     "@types/jest": "25.2.3",
     "@types/node": "13.13.18",
     "@types/puppeteer": "2.1.3",
-    "puppeteer": "2.1.1",
-    "rollup-plugin-dotenv": "0.3.0"
+    "puppeteer": "2.1.1"
   },
   "@comments": {
     "scripts": {

--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -8,9 +8,17 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface DcHeader {
         /**
+          * URL to the community without the latest "/"
+         */
+        "community": string;
+        /**
           * Link to follow in order to prompt user to donate
          */
         "donateURL": string;
+        /**
+          * URL to the component host without the latest "/"
+         */
+        "host": string;
         /**
           * The links you need to display within the header this string needs to be JSON (able to JSON.parse)
          */
@@ -23,6 +31,10 @@ export namespace Components {
         "open": boolean;
     }
     interface DcUserItems {
+        /**
+          * URL to the community
+         */
+        "community": string;
         /**
           * An object with the user data. Follows Discourse structure as https://docs.discourse.org/#tag/Users/paths/~1users~1{username}.json/get
          */
@@ -64,9 +76,17 @@ declare global {
 declare namespace LocalJSX {
     interface DcHeader {
         /**
+          * URL to the community without the latest "/"
+         */
+        "community"?: string;
+        /**
           * Link to follow in order to prompt user to donate
          */
         "donateURL"?: string;
+        /**
+          * URL to the component host without the latest "/"
+         */
+        "host"?: string;
         /**
           * The links you need to display within the header this string needs to be JSON (able to JSON.parse)
          */
@@ -80,6 +100,10 @@ declare namespace LocalJSX {
         "open"?: boolean;
     }
     interface DcUserItems {
+        /**
+          * URL to the community
+         */
+        "community"?: string;
         /**
           * An object with the user data. Follows Discourse structure as https://docs.discourse.org/#tag/Users/paths/~1users~1{username}.json/get
          */

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -38,7 +38,19 @@ export class Header {
   /**
    * Link to follow in order to prompt user to donate
    */
-  @Prop() donateURL: string;
+  @Prop() donateURL: string = "https://membership.debtcollective.org";
+
+  /**
+   * URL to the community
+   * without the latest "/"
+   */
+  @Prop() community: string = "https://community.debtcollective.org";
+
+  /**
+   * URL to the component host
+   * without the latest "/"
+   */
+  @Prop() host: string;
 
   /**
    * An object with the user data. Follows Discourse structure as
@@ -82,7 +94,7 @@ export class Header {
   }
 
   async syncCurrentUser() {
-    const user = await syncCurrentUser(process.env.COMMUNITY_URL);
+    const user = await syncCurrentUser(this.community);
     this.user = user;
   }
 
@@ -128,10 +140,10 @@ export class Header {
           </nav>
           <div class="session-items">
             {user ? (
-              <dc-user-items user={user} />
+              <dc-user-items user={user} community={this.community} />
             ) : (
               <div class="session-links">
-                <a href={loginURL} class="btn btn-outline">
+                <a href={loginURL({ host: this.host })} class="btn btn-outline">
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
                 <a href={this.donateURL} class="btn btn-primary">

--- a/packages/header-component/src/components/dc-header/dc-user-items.tsx
+++ b/packages/header-component/src/components/dc-header/dc-user-items.tsx
@@ -8,6 +8,10 @@ import { preffixCommunityURL, getAvatarURL } from "../../utils/community";
 })
 export class Menu {
   /**
+   * URL to the community
+   */
+  @Prop() community: string;
+  /**
    * An object with the user data. Follows Discourse structure as
    * https://docs.discourse.org/#tag/Users/paths/~1users~1{username}.json/get
    */
@@ -30,7 +34,10 @@ export class Menu {
       <Host class="session-user-items">
         <a
           class="notification-link"
-          href={preffixCommunityURL(`u/${this.user.username}/messages`)}
+          href={preffixCommunityURL(
+            this.community,
+            `u/${this.user.username}/messages`
+          )}
         >
           <div class="notification-icon icons">
             <div id="inbox" class="material-icons">
@@ -45,7 +52,10 @@ export class Menu {
         </a>
         <a
           class="notification-link"
-          href={preffixCommunityURL(`u/${this.user.username}/notifications`)}
+          href={preffixCommunityURL(
+            this.community,
+            `u/${this.user.username}/notifications`
+          )}
         >
           <div class="notification-icon icons">
             <div id="notifications" class="material-icons">
@@ -60,14 +70,14 @@ export class Menu {
         </a>
         <a
           id="current-user"
-          href={preffixCommunityURL(`u/${this.user.username}`)}
+          href={preffixCommunityURL(this.community, `u/${this.user.username}`)}
           target="_blank"
         >
           <img
             alt="Profile picture"
             width="32"
             height="32"
-            src={getAvatarURL(this.user)}
+            src={getAvatarURL(this.user, this.community)}
             title={this.user.username}
             class="avatar"
           />

--- a/packages/header-component/src/components/dc-header/readme.md
+++ b/packages/header-component/src/components/dc-header/readme.md
@@ -5,9 +5,10 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                           | Type                                                                                                                                                   | Default     |
-| -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| `user`   | --        | An object with the user data. Follows Discourse structure as https://docs.discourse.org/#tag/Users/paths/~1users~1{username}.json/get | `{ id: number; admin: boolean; avatar_template: string; username: string; unread_notifications: number; unread_high_priority_notifications: number; }` | `undefined` |
+| Property    | Attribute   | Description                                                                                                                           | Type                                                                                                                                                   | Default     |
+| ----------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `community` | `community` | URL to the community                                                                                                                  | `string`                                                                                                                                               | `undefined` |
+| `user`      | --          | An object with the user data. Follows Discourse structure as https://docs.discourse.org/#tag/Users/paths/~1users~1{username}.json/get | `{ id: number; admin: boolean; avatar_template: string; username: string; unread_notifications: number; unread_high_priority_notifications: number; }` | `undefined` |
 
 
 ## Dependencies

--- a/packages/header-component/src/index.html
+++ b/packages/header-component/src/index.html
@@ -1,21 +1,33 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en" style="height: 100%;">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-  <title>Stencil Component Starter</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Stencil Component Starter</title>
 
-  <script type="module" src="/build/header.esm.js"></script>
-  <script nomodule src="/build/header.js"></script>
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;600&display=swap" rel="stylesheet">
+    <script type="module" src="/build/header.esm.js"></script>
+    <script nomodule src="/build/header.js"></script>
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body
+    style="background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%); height: 100%;"
+  >
+    <dc-header
+      host="http://lvh.me:3333"
+      community="http://lvh.me:3000"
+      links='[{"href":"http://debtcollective.org/","text":"About us"}, {"href":"https://community.debtcollective.org/","text":"Community"}, {"href":"https://teespring.com/stores/debt-collective","text":"Store"}]'
+    ></dc-header>
 
-</head>
-<body style="background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%); height: 100%;">
-
-  <dc-header links='[{"href":"http://debtcollective.org/","text":"About us"}, {"href":"https://community.debtcollective.org/","text":"Community"}, {"href":"https://teespring.com/stores/debt-collective","text":"Store"}]'></dc-header>
-  
-  <!-- You can choose to render custom navigation, check the README.md file and restart the stencil server after change index.html -->
-
-</body>
+    <!-- You can choose to render custom navigation, check the README.md file and restart the stencil server after change index.html -->
+  </body>
 </html>

--- a/packages/header-component/src/index.html
+++ b/packages/header-component/src/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <title>Stencil Component Starter</title>
 
-  <script type="module" src="/build/web-header.esm.js"></script>
-  <script nomodule src="/build/web-header.js"></script>
+  <script type="module" src="/build/header.esm.js"></script>
+  <script nomodule src="/build/header.js"></script>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;600&display=swap" rel="stylesheet">
 

--- a/packages/header-component/src/utils/community.ts
+++ b/packages/header-component/src/utils/community.ts
@@ -1,31 +1,36 @@
-const redirectParam = `return_url=${process.env.HOST_URL}`;
+const redirectParam = host => `return_url=${host}`;
 
 /**
  * Fixed link for login to allow user navigate to the community and be redirected
  * back to the host app after complete flow
  */
-export const loginURL = `${process.env.COMMUNITY_URL}/session/sso_cookies?${redirectParam}`;
+export const loginURL = ({ host }) =>
+  `${host}/session/sso_cookies?${redirectParam(host)}`;
 
 /**
  * Fixed link for signup to allow user navigate to the community and be redirected
  * back to the host app after complete flow
  */
-export const signupURL = `${process.env.COMMUNITY_URL}/session/sso_cookies/signup?${redirectParam}`;
+export const signupURL = ({ host }) =>
+  `${host}/session/sso_cookies/signup?${redirectParam(host)}`;
 
 /**
  * preffix a given string with the base community URL.
- * 
+ *
  * @param str typically a url that needs to be preffixed with community base url
  */
-export const preffixCommunityURL = (str) => `${process.env.COMMUNITY_URL}/${str}`;
+export const preffixCommunityURL = (community, str) => `${community}/${str}`;
 
 /**
  * Takes an object with avatar_template (typically user) and return a full
  * URL that can be used to load the avatar image
- * 
+ *
  * @param User object with avatar_template
  * @param size number to define the pixel of avatar picture
  */
-export const getAvatarURL = ({ avatar_template }, size = 64) => {
-  return preffixCommunityURL(avatar_template.replace(`{size}`, size));
+export const getAvatarURL = ({ avatar_template }, community, size = 64) => {
+  return preffixCommunityURL(
+    community,
+    avatar_template.replace(`{size}`, size)
+  );
 };

--- a/packages/header-component/stencil.config.ts
+++ b/packages/header-component/stencil.config.ts
@@ -2,7 +2,7 @@ import { Config } from '@stencil/core';
 import dotEnvPlugin from 'rollup-plugin-dotenv';
 
 export const config: Config = {
-  namespace: 'web-header',
+  namespace: 'header',
   taskQueue: 'async',
   outputTargets: [
     {

--- a/packages/header-component/stencil.config.ts
+++ b/packages/header-component/stencil.config.ts
@@ -1,5 +1,4 @@
 import { Config } from '@stencil/core';
-import dotEnvPlugin from 'rollup-plugin-dotenv';
 
 export const config: Config = {
   namespace: 'header',
@@ -16,8 +15,5 @@ export const config: Config = {
       type: 'www',
       serviceWorker: null // disable service workers
     }
-  ],
-  plugins: [
-    dotEnvPlugin()
   ]
 };


### PR DESCRIPTION
**What:**
Avoid the complexity that the usage of env variables brings in order to aim for an easier integration process.

**Why:**
We are getting errors at the moment to make the integration and this may be an step further to make things easier

**How:**
Remove `rollup-plugin-dotenv` dependency and update the code accordingly.
