### PR TITLE
fix(header): use community url to create login/signup links

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -143,7 +143,7 @@ export class Header {
               <dc-user-items user={user} community={this.community} />
             ) : (
               <div class="session-links">
-                <a href={loginURL({ host: this.host })} class="btn btn-outline">
+                <a href={loginURL({ community: this.community, host: this.host })} class="btn btn-outline">
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
                 <a href={this.donateURL} class="btn btn-primary">

--- a/packages/header-component/src/utils/community.ts
+++ b/packages/header-component/src/utils/community.ts
@@ -4,15 +4,15 @@ const redirectParam = host => `return_url=${host}`;
  * Fixed link for login to allow user navigate to the community and be redirected
  * back to the host app after complete flow
  */
-export const loginURL = ({ host }) =>
-  `${host}/session/sso_cookies?${redirectParam(host)}`;
+export const loginURL = ({ host, community }) =>
+  `${community}/session/sso_cookies?${redirectParam(host)}`;
 
 /**
  * Fixed link for signup to allow user navigate to the community and be redirected
  * back to the host app after complete flow
  */
-export const signupURL = ({ host }) =>
-  `${host}/session/sso_cookies/signup?${redirectParam(host)}`;
+export const signupURL = ({ host, community }) =>
+  `${community}/session/sso_cookies/signup?${redirectParam(host)}`;
 
 /**
  * preffix a given string with the base community URL.


### PR DESCRIPTION
**What:**
create login and signup url links using community prop together with host for redirection.

**Why:**
The session is being handle by our community, before we were creating the links only with host url which is wrong.

**Media:**
https://www.loom.com/share/bca167605c014a0985c1de64c3b3b194