### PR TITLE
Header component dropdown

### DIFF
--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -43,6 +43,14 @@ export namespace Components {
           * The links you need to display within the header this string needs to be JSON (able to JSON.parse)
          */
         "links": string;
+        /**
+          * Logo src to use a custom image for the header
+         */
+        "logo": string;
+        /**
+          * Logo small src to use a custom image for the header in mobile
+         */
+        "logoSmall": string;
     }
     interface DcMenu {
         /**
@@ -145,6 +153,14 @@ declare namespace LocalJSX {
           * The links you need to display within the header this string needs to be JSON (able to JSON.parse)
          */
         "links"?: string;
+        /**
+          * Logo src to use a custom image for the header
+         */
+        "logo"?: string;
+        /**
+          * Logo small src to use a custom image for the header in mobile
+         */
+        "logoSmall"?: string;
     }
     interface DcMenu {
         "onToggleMenu"?: (event: CustomEvent<void>) => void;

--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -6,6 +6,16 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
+    interface DcDropdown {
+        /**
+          * Items to be displayed in the dropdown
+         */
+        "items": Array<{ text: string; href: string, description: string }>;
+        /**
+          * label for the dropdown nav item
+         */
+        "label": string;
+    }
     interface DcHeader {
         /**
           * URL to the community without the latest "/"
@@ -49,6 +59,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLDcDropdownElement extends Components.DcDropdown, HTMLStencilElement {
+    }
+    var HTMLDcDropdownElement: {
+        prototype: HTMLDcDropdownElement;
+        new (): HTMLDcDropdownElement;
+    };
     interface HTMLDcHeaderElement extends Components.DcHeader, HTMLStencilElement {
     }
     var HTMLDcHeaderElement: {
@@ -68,12 +84,23 @@ declare global {
         new (): HTMLDcUserItemsElement;
     };
     interface HTMLElementTagNameMap {
+        "dc-dropdown": HTMLDcDropdownElement;
         "dc-header": HTMLDcHeaderElement;
         "dc-menu": HTMLDcMenuElement;
         "dc-user-items": HTMLDcUserItemsElement;
     }
 }
 declare namespace LocalJSX {
+    interface DcDropdown {
+        /**
+          * Items to be displayed in the dropdown
+         */
+        "items"?: Array<{ text: string; href: string, description: string }>;
+        /**
+          * label for the dropdown nav item
+         */
+        "label"?: string;
+    }
     interface DcHeader {
         /**
           * URL to the community without the latest "/"
@@ -117,6 +144,7 @@ declare namespace LocalJSX {
   };
     }
     interface IntrinsicElements {
+        "dc-dropdown": DcDropdown;
         "dc-header": DcHeader;
         "dc-menu": DcMenu;
         "dc-user-items": DcUserItems;
@@ -126,6 +154,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "dc-dropdown": LocalJSX.DcDropdown & JSXBase.HTMLAttributes<HTMLDcDropdownElement>;
             "dc-header": LocalJSX.DcHeader & JSXBase.HTMLAttributes<HTMLDcHeaderElement>;
             "dc-menu": LocalJSX.DcMenu & JSXBase.HTMLAttributes<HTMLDcMenuElement>;
             "dc-user-items": LocalJSX.DcUserItems & JSXBase.HTMLAttributes<HTMLDcUserItemsElement>;

--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -6,6 +6,16 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
+    interface DcCollapser {
+        /**
+          * Items to be displayed in the collapser
+         */
+        "items": Array<{ text: string; href: string, description: string }>;
+        /**
+          * label for the collapser nav item
+         */
+        "label": string;
+    }
     interface DcDropdown {
         /**
           * Items to be displayed in the dropdown
@@ -59,6 +69,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLDcCollapserElement extends Components.DcCollapser, HTMLStencilElement {
+    }
+    var HTMLDcCollapserElement: {
+        prototype: HTMLDcCollapserElement;
+        new (): HTMLDcCollapserElement;
+    };
     interface HTMLDcDropdownElement extends Components.DcDropdown, HTMLStencilElement {
     }
     var HTMLDcDropdownElement: {
@@ -84,6 +100,7 @@ declare global {
         new (): HTMLDcUserItemsElement;
     };
     interface HTMLElementTagNameMap {
+        "dc-collapser": HTMLDcCollapserElement;
         "dc-dropdown": HTMLDcDropdownElement;
         "dc-header": HTMLDcHeaderElement;
         "dc-menu": HTMLDcMenuElement;
@@ -91,6 +108,16 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface DcCollapser {
+        /**
+          * Items to be displayed in the collapser
+         */
+        "items"?: Array<{ text: string; href: string, description: string }>;
+        /**
+          * label for the collapser nav item
+         */
+        "label"?: string;
+    }
     interface DcDropdown {
         /**
           * Items to be displayed in the dropdown
@@ -144,6 +171,7 @@ declare namespace LocalJSX {
   };
     }
     interface IntrinsicElements {
+        "dc-collapser": DcCollapser;
         "dc-dropdown": DcDropdown;
         "dc-header": DcHeader;
         "dc-menu": DcMenu;
@@ -154,6 +182,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "dc-collapser": LocalJSX.DcCollapser & JSXBase.HTMLAttributes<HTMLDcCollapserElement>;
             "dc-dropdown": LocalJSX.DcDropdown & JSXBase.HTMLAttributes<HTMLDcDropdownElement>;
             "dc-header": LocalJSX.DcHeader & JSXBase.HTMLAttributes<HTMLDcHeaderElement>;
             "dc-menu": LocalJSX.DcMenu & JSXBase.HTMLAttributes<HTMLDcMenuElement>;

--- a/packages/header-component/src/components/dc-header/dc-collapser.css
+++ b/packages/header-component/src/components/dc-header/dc-collapser.css
@@ -1,0 +1,47 @@
+:host .collapser-container {
+  position: relative;
+  display: block;
+}
+
+:host .collapser-items {
+  left: -80%;
+  top: 2rem;
+  border-radius: 0 0.5rem 0.5rem;
+  background-color: var(--main-bg-color);
+  padding: 0;
+  cursor: pointer;
+}
+
+:host .collapser-items.open {
+  opacity: 1;
+  transition: opacity 0.1s ease-in;
+  visibility: visible;
+  list-style: none;
+}
+
+:host .collapser-items.hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+:host .collapser-items .collapser-item:hover .collapser-item-text  {
+  color: var(--brand-color);
+}
+
+:host .collapser-items .collapser-item .collapser-item-text {
+  color: var(--disabled-text-color);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+:host .collapser-items .collapser-item .collapser-item-description {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: var(--text-color);
+}
+
+@media (min-width: 768px) {
+  :host .collapser-container {
+    display: none;
+  }
+}

--- a/packages/header-component/src/components/dc-header/dc-collapser.css
+++ b/packages/header-component/src/components/dc-header/dc-collapser.css
@@ -1,8 +1,3 @@
-:host .collapser-container {
-  position: relative;
-  display: block;
-}
-
 :host .collapser-items {
   left: -80%;
   top: 2rem;
@@ -13,15 +8,11 @@
 }
 
 :host .collapser-items.open {
-  opacity: 1;
-  transition: opacity 0.1s ease-in;
-  visibility: visible;
-  list-style: none;
+  display: block;
 }
 
 :host .collapser-items.hidden {
-  visibility: hidden;
-  opacity: 0;
+  display: none;
 }
 
 :host .collapser-items .collapser-item:hover .collapser-item-text  {
@@ -38,10 +29,4 @@
   font-size: 0.75rem;
   line-height: 1rem;
   color: var(--text-color);
-}
-
-@media (min-width: 768px) {
-  :host .collapser-container {
-    display: none;
-  }
 }

--- a/packages/header-component/src/components/dc-header/dc-collapser.tsx
+++ b/packages/header-component/src/components/dc-header/dc-collapser.tsx
@@ -1,0 +1,58 @@
+import {
+  Component,
+  h,
+  State,
+  Prop,
+} from "@stencil/core";
+
+@Component({
+  assetsDirs: ["assets"],
+  tag: "dc-collapser",
+  styleUrl: "dc-collapser.css"
+})
+export class Collapser {
+  /**
+   * label for the collapser nav item
+   */
+  @Prop() label: string;
+
+  /**
+   * Items to be displayed in the collapser
+   */
+  @Prop() items: Array<{ text: string; href: string, description: string }>;
+  
+  @State() open: boolean;
+
+  toggleCollapser() {
+    this.open = !this.open;
+  }
+
+  render() {
+    return (
+      <div class="collapser-container nav-item">
+        <button
+          class="nav-link btn btn-transparent"
+          onClick={this.toggleCollapser.bind(this)}
+        >
+          {this.label || ''} 
+          <span class="material-icons">
+            {this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+          </span>
+        </button>
+        <ul class={`collapser-items ${this.open ? "open " : "hidden"}`}>
+          {
+            this.items.map(item => (
+              <li class="collapser-item" onClick={() => {
+                window.open(item.href, "_self");
+              }}>
+                <a href={item.href} class="collapser-item-text">{item.text}</a>
+                <p class="collapser-item-description">{item.description}</p>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    );
+  }
+}
+  

--- a/packages/header-component/src/components/dc-header/dc-collapser.tsx
+++ b/packages/header-component/src/components/dc-header/dc-collapser.tsx
@@ -29,7 +29,7 @@ export class Collapser {
 
   render() {
     return (
-      <div class="collapser-container nav-item">
+      <div class="nav-item">
         <button
           class="nav-link btn btn-transparent"
           onClick={this.toggleCollapser.bind(this)}

--- a/packages/header-component/src/components/dc-header/dc-dropdown.css
+++ b/packages/header-component/src/components/dc-header/dc-dropdown.css
@@ -6,14 +6,14 @@
 :host .dropdown-items {
   position: absolute;
   left: -50%;
-  top: 1.5rem;
+  top: 2rem;
   border-radius: 0 0.5rem 0.5rem;
   background-color: var(--main-bg-color);
   padding: 0;
   cursor: pointer;
   max-width: 28rem;
   min-width: 16rem;
-  overflow: hidden;
+  box-shadow: 0px 0px 8px rgba(37, 40, 43, 0.12);
 }
 
 :host .dropdown-items.open {
@@ -29,22 +29,17 @@
 }
 
 :host .dropdown-items .dropdown-item {
+  display: block;
   padding: 0.5rem 1rem;
-}
-
-:host .dropdown-items .dropdown-item:hover {
-  background-color: rgba(255, 70, 48, 0.1);
-  transition: background-color 0.1s ease-in;
-}
-
-:host .dropdown-items .dropdown-item:hover .dropdown-item-text  {
-  color: var(--brand-color);
-}
-
-:host .dropdown-items .dropdown-item .dropdown-item-text {
   color: var(--disabled-text-color);
   font-size: 0.875rem;
   font-weight: 600;
+}
+
+:host .dropdown-items .dropdown-item:hover, :host .dropdown-items .dropdown-item:focus {
+  background-color: rgba(255, 70, 48, 0.1);
+  transition: background-color 0.1s ease-in;
+  color: var(--brand-color);
 }
 
 :host .dropdown-items .dropdown-item .dropdown-item-description {

--- a/packages/header-component/src/components/dc-header/dc-dropdown.css
+++ b/packages/header-component/src/components/dc-header/dc-dropdown.css
@@ -1,0 +1,60 @@
+:host .dropdown-container {
+  position: relative;
+  display: none;
+}
+
+:host .dropdown-items {
+  position: absolute;
+  left: -50%;
+  top: 1.5rem;
+  border-radius: 0 0.5rem 0.5rem;
+  background-color: var(--main-bg-color);
+  padding: 0;
+  cursor: pointer;
+  max-width: 28rem;
+  min-width: 16rem;
+  overflow: hidden;
+}
+
+:host .dropdown-items.open {
+  opacity: 1;
+  transition: opacity 0.1s ease-in;
+  visibility: visible;
+  list-style: none;
+}
+
+:host .dropdown-items.hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+:host .dropdown-items .dropdown-item {
+  padding: 0.5rem 1rem;
+}
+
+:host .dropdown-items .dropdown-item:hover {
+  background-color: rgba(255, 70, 48, 0.1);
+  transition: background-color 0.1s ease-in;
+}
+
+:host .dropdown-items .dropdown-item:hover .dropdown-item-text  {
+  color: var(--brand-color);
+}
+
+:host .dropdown-items .dropdown-item .dropdown-item-text {
+  color: var(--disabled-text-color);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+:host .dropdown-items .dropdown-item .dropdown-item-description {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: var(--text-color);
+}
+
+@media (min-width: 768px) {
+  :host .dropdown-container {
+    display: block;
+  }
+}

--- a/packages/header-component/src/components/dc-header/dc-dropdown.tsx
+++ b/packages/header-component/src/components/dc-header/dc-dropdown.tsx
@@ -1,0 +1,86 @@
+import {
+  Component,
+  h,
+  State,
+  Prop,
+  Listen
+} from "@stencil/core";
+
+@Component({
+  assetsDirs: ["assets"],
+  tag: "dc-dropdown",
+  styleUrl: "dc-dropdown.css"
+})
+export class Dropdown {
+  /**
+   * label for the dropdown nav item
+   */
+  @Prop() label: string;
+
+  /**
+   * Items to be displayed in the dropdown
+   */
+  @Prop() items: Array<{ text: string; href: string, description: string }>;
+  
+  @State() open: boolean;
+
+  /**
+   * Event to detect outside clicks from the dropdown
+   */
+
+  @Listen('click', { target: 'document' })
+  handleClickOutside(event) {
+    const target = event.composedPath()[0];
+
+    if (this?.dropdownTrigger?.contains(target) || this?.dropdownItems?.contains(target)) {
+      return;
+    }
+
+    this.closeDropdown();
+  }
+
+  dropdownTrigger!: Node;
+
+  dropdownItems!: Node;
+
+  toggleDropdown() {
+    this.open = !this.open;
+  }
+
+  closeDropdown() {
+    this.open = false;
+  }
+
+  render() {
+    return (
+      <div class={`dropdown-container nav-item`}>
+        <button
+          class="nav-link btn btn-transparent"
+          onClick={this.toggleDropdown.bind(this)}
+          ref={(el) => this.dropdownTrigger = el}
+        >
+          {this.label || ''} 
+          <span class="material-icons">
+            {this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+          </span>
+        </button>
+        <ul
+          class={`dropdown-items ${this.open ? "open " : "hidden"}`}
+          onMouseLeave={this.closeDropdown.bind(this)}
+          ref={(el) => this.dropdownItems = el}
+        >
+          {
+            this.items.map(item => (
+              <li class="dropdown-item" onClick={() => {
+                window.open(item.href, "_self");
+              }}>
+                <a href={item.href} class="dropdown-item-text">{item.text}</a>
+                <p class="dropdown-item-description">{item.description}</p>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    );
+  }
+}

--- a/packages/header-component/src/components/dc-header/dc-dropdown.tsx
+++ b/packages/header-component/src/components/dc-header/dc-dropdown.tsx
@@ -27,7 +27,6 @@ export class Dropdown {
   /**
    * Event to detect outside clicks from the dropdown
    */
-
   @Listen('click', { target: 'document' })
   handleClickOutside(event) {
     const target = event.composedPath()[0];
@@ -64,22 +63,20 @@ export class Dropdown {
             {this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
           </span>
         </button>
-        <ul
+        <div
           class={`dropdown-items ${this.open ? "open " : "hidden"}`}
           onMouseLeave={this.closeDropdown.bind(this)}
           ref={(el) => this.dropdownItems = el}
         >
           {
             this.items.map(item => (
-              <li class="dropdown-item" onClick={() => {
-                window.open(item.href, "_self");
-              }}>
-                <a href={item.href} class="dropdown-item-text">{item.text}</a>
+              <a href={item.href} class="dropdown-item">
+                {item.text}
                 <p class="dropdown-item-description">{item.description}</p>
-              </li>
+              </a>
             ))
           }
-        </ul>
+        </div>
       </div>
     );
   }

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -3,6 +3,7 @@
   --button-color: #ff4630;
   --button-hover-color: #ee2812;
   --text-color: #2b2b2b;
+  --disabled-text-color: #52575C;
   --font-size: 1rem;
   --column-gap: 15px;
   --main-bg-color: #fbfbfb;

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -11,6 +11,7 @@ import {
 import { syncCurrentUser } from "../../services/session";
 import "./dc-menu";
 import "./dc-user-items";
+import "./dc-dropdown";
 import { loginURL } from "../../utils/community";
 
 type User = {
@@ -51,6 +52,16 @@ export class Header {
    * without the latest "/"
    */
   @Prop() host: string;
+
+  /**
+   * Logo src to use a custom image for the header
+   */
+  @Prop() logo: string;
+
+  /**
+   * Logo small src to use a custom image for the header in mobile
+   */
+  @Prop() logoSmall: string;
 
   /**
    * An object with the user data. Follows Discourse structure as
@@ -112,7 +123,7 @@ export class Header {
           <a class="logo-link d-md-flex" href="/">
             <img
               class="logo"
-              src={getAssetPath(`./assets/${this._logo}`)}
+              src={this.logo || getAssetPath(`./assets/${this._logo}`)}
               alt="The Debtcollective"
             />
           </a>
@@ -122,7 +133,7 @@ export class Header {
           >
             <img
               class="logo"
-              src={getAssetPath(`./assets/${this._logoSmall}`)}
+              src={this.logoSmall || getAssetPath(`./assets/${this._logoSmall}`)}
               alt="The Debtcollective"
             />
             <span class="material-icons ml-1">keyboard_arrow_right</span>
@@ -136,6 +147,15 @@ export class Header {
                   </a>
                 </div>
               ))}
+              <dc-dropdown label="Hey there" items={[{
+                text: 'Hey',
+                href: '/',
+                description: 'This is a description'
+              }, {
+                text: 'Hey',
+                href: '/',
+                description: 'This is a description'
+              }]} />
             </slot>
           </nav>
           <div class="session-items">


### PR DESCRIPTION
**What:**
- Create a header component dropdown
- Create a header component collapsed for mobile
- Support logo and logoSmall as props for the header to use a custom logo (the reason to add this is due to this stencil issue: https://github.com/ionic-team/stencil/issues/1868, when attempting to load the assets from stencil, it tries to reach the assets from the local path of the project instead of the assets from the `dist` folder, which causes not loading the logo, see next attachment)
![image](https://user-images.githubusercontent.com/20747535/93541828-1468c600-f91d-11ea-88dd-4514da54b7b7.png)


**Why:**
Relates to: https://app.asana.com/0/1159164196409129/1193523850025722/f

**How:**
- Create dropdown to use it on desktop
- Create collapsed to use it on mobile


#### Media:

https://www.loom.com/share/88ed7a9f417e4844a4eb612852700661