### PR TITLE
refactor(header-component): add logosmall prop as lowercase

### DIFF
--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -50,9 +50,13 @@ export namespace Components {
         /**
           * Logo small src to use a custom image for the header in mobile
          */
-        "logoSmall": string;
+        "logosmall": string;
     }
     interface DcMenu {
+        /**
+          * Logo src to use a custom image for the header
+         */
+        "logo": string;
         /**
           * Wether or not the mobile menu is displayed
          */
@@ -160,9 +164,13 @@ declare namespace LocalJSX {
         /**
           * Logo small src to use a custom image for the header in mobile
          */
-        "logoSmall"?: string;
+        "logosmall"?: string;
     }
     interface DcMenu {
+        /**
+          * Logo src to use a custom image for the header
+         */
+        "logo"?: string;
         "onToggleMenu"?: (event: CustomEvent<void>) => void;
         /**
           * Wether or not the mobile menu is displayed

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -60,7 +60,7 @@ export class Header {
   /**
    * Logo small src to use a custom image for the header in mobile
    */
-  @Prop() logoSmall: string;
+  @Prop() logosmall: string;
 
   /**
    * An object with the user data. Follows Discourse structure as
@@ -132,7 +132,7 @@ export class Header {
           >
             <img
               class="logo"
-              src={this.logoSmall || getAssetPath(`./assets/${this._logoSmall}`)}
+              src={this.logosmall || getAssetPath(`./assets/${this._logoSmall}`)}
               alt="The Debtcollective"
             />
             <span class="material-icons ml-1">keyboard_arrow_right</span>

--- a/packages/header-component/src/components/dc-header/dc-menu.tsx
+++ b/packages/header-component/src/components/dc-header/dc-menu.tsx
@@ -18,6 +18,11 @@ export class Menu {
    */
   @Prop() open: boolean;
 
+  /**
+   * Logo src to use a custom image for the header
+   */
+  @Prop() logo: string;
+
   @Event() toggleMenu: EventEmitter<void>;
 
   /**
@@ -38,7 +43,7 @@ export class Menu {
             <a href="/" class="btn-transparent">
               <img
                 class="menu-logo"
-                src={getAssetPath(`./assets/${this._logo}`)}
+                src={this.logo || getAssetPath(`./assets/${this._logo}`)}
                 alt="The Debtcollective"
               />
             </a>


### PR DESCRIPTION
**What:**
Add `logosmall` prop as lowercase and add logo prop to dc menu

**Why:**
Due to HTML attributes are case insensitive, the logo small prop was not being applied

**How:**
- Set prop as lowercase
- Pass logo prop to dc menu in order to use the same image that was passed by props to the header component
