### PR TITLE
Add member hub link if user is authenticated

### DIFF
--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -51,6 +51,10 @@ export namespace Components {
           * Logo small src to use a custom image for the header in mobile
          */
         "logosmall": string;
+        /**
+          * URL to the member hub page
+         */
+        "memberhuburl"?: string;
     }
     interface DcMenu {
         /**
@@ -189,6 +193,10 @@ declare namespace LocalJSX {
           * Logo small src to use a custom image for the header in mobile
          */
         "logosmall"?: string;
+        /**
+          * URL to the member hub page
+         */
+        "memberhuburl"?: string;
     }
     interface DcMenu {
         /**

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -45,6 +45,11 @@ export class Header {
    * without the latest "/"
    */
   @Prop() community: string = "https://community.debtcollective.org";
+  
+  /**
+   * URL to the member hub page
+   */
+  @Prop() memberhuburl?: string = "https://debtcollective.org/hub";
 
   /**
    * URL to the component host
@@ -94,6 +99,16 @@ export class Header {
     this._links = JSON.parse(newValue);
   }
 
+  @Watch("user")
+  userDidChage(newUser) {
+    if (newUser) {
+      this._links.unshift({
+        text: 'Member hub',
+        href: this.memberhuburl
+      })
+    }
+  }
+
   @Listen("toggleMenu")
   toggleMenuHandler() {
     this.toggleMenu();
@@ -105,6 +120,7 @@ export class Header {
 
   async syncCurrentUser() {
     const user = await syncCurrentUser(this.community);
+
     this.user = user;
   }
 

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -99,16 +99,6 @@ export class Header {
     this._links = JSON.parse(newValue);
   }
 
-  @Watch("user")
-  userDidChage(newUser) {
-    if (newUser) {
-      this._links.unshift({
-        text: 'Member hub',
-        href: this.memberhuburl
-      })
-    }
-  }
-
   @Listen("toggleMenu")
   toggleMenuHandler() {
     this.toggleMenu();
@@ -131,6 +121,13 @@ export class Header {
 
   render() {
     const user = this.user;
+    const authLinks = [
+      {
+        text: 'Member hub',
+        href: this.memberhuburl
+      }
+    ];
+    const linksToRender = this.user?.id ? [...authLinks, ...this._links] : this._links;
 
     return (
       <Host>
@@ -155,7 +152,7 @@ export class Header {
           </button>
           <nav class="nav">
             <slot name="header">
-              {this._links.map(({ text, href }) => (
+              {linksToRender.map(({ text, href }) => (
                 <div class="nav-item d-md-flex">
                   <a class="nav-link" href={href}>
                     {text}
@@ -181,7 +178,7 @@ export class Header {
         </header>
         <dc-menu open={this.isMenuOpen} logo={this.logo}>
           <slot name="menu">
-            {this._links.map(({ text, href }) => (
+            {linksToRender.map(({ text, href }) => (
               <div class="nav-item">
                 <a class="nav-link" href={href}>
                   {text}


### PR DESCRIPTION
**What:**
Add member hub link if the user is authenticated

**Why:**
Relates to: https://app.asana.com/0/1159164196409156/1194956796156396/f

**How:**
- Include a prop `memberhuburl` as a reference for the member hub link
- Include `Member hub` link if the user is authenticated


#### Media:
![image](https://user-images.githubusercontent.com/20747535/93836323-003c0600-fc48-11ea-82a6-2def5decacb1.png)
