### PR TITLE
Fix the dc menu to be visible while scrolling

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-menu.css
+++ b/packages/header-component/src/components/dc-header/dc-menu.css
@@ -20,7 +20,7 @@
   justify-content: flex-start;
   left: 0;
   padding: 0;
-  position: absolute;
+  position: fixed;
   top: 0;
   transition: transform ease 0.216s;
   width: 75%;


### PR DESCRIPTION
**What:**
Fix the dc menu to be visible while scrolling

**Why:**
Closes: https://app.asana.com/0/1196225495304457/1196225495304518/f

**How:**
- Use fixed position to keep the menu in the screen while scrolling

#### Media
https://www.loom.com/share/92be9169f44f4de0b884443816c58797