### PR TITLE
Display logo correctly in safari

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-menu.tsx
+++ b/packages/header-component/src/components/dc-header/dc-menu.tsx
@@ -40,7 +40,7 @@ export class Menu {
         <div class="menu-cloak" onClick={this.toggleMenuHandler.bind(this)} />
         <div class="menu">
           <div class="nav-header">
-            <a href="/" class="btn-transparent">
+            <a href="/">
               <img
                 class="menu-logo"
                 src={this.logo || getAssetPath(`./assets/${this._logo}`)}


### PR DESCRIPTION
**What:**
Display logo correctly in safari

**Why:**
Closes: https://app.asana.com/0/1196225495304457/1196874789481257/f

**How:**
There was a class applied for the `anchor` tag that was adding a `flex` display, this was breaking the logo in Safari, by removing the class `btn-transparent` it worked as expected


#### Media:
https://www.loom.com/share/70002ba4f468471f943d217c1d56a1a1