### PR TITLE
fix(header-component): display dc-menu in resolutions lower than 1024px

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-dropdown.css
+++ b/packages/header-component/src/components/dc-header/dc-dropdown.css
@@ -42,7 +42,7 @@
   color: var(--brand-color);
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   :host .dropdown-container {
     display: block;
   }

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -12,6 +12,10 @@
   --main-font: "Libre Franklin", sans-serif;
 }
 
+:host * {
+  font-family: var(--main-font);
+}
+
 :host a {
   text-decoration: none;
 }
@@ -25,7 +29,6 @@
   box-shadow: 0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.25);
   box-sizing: border-box;
   display: flex;
-  font-family: var(--main-font);
   height: 5rem;
   justify-content: flex-start;
   left: 0;
@@ -177,7 +180,7 @@
   display: none;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   :host .d-md-flex {
     display: flex;
   }
@@ -187,7 +190,7 @@
   display: flex;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   :host .d-md-none {
     display: none;
   }

--- a/packages/header-component/src/components/dc-header/dc-menu.css
+++ b/packages/header-component/src/components/dc-header/dc-menu.css
@@ -15,7 +15,6 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  font-family: var(--main-font);
   height: 100vh;
   justify-content: flex-start;
   left: 0;


### PR DESCRIPTION
**What:**
- Display dc-menu in resolutions lower than 1024px
- Fix the font-family for the dc-dropdown and dc-collapser

**Why:**
Closes:
- https://app.asana.com/0/1196225495304457/1195563458819145/f
- https://app.asana.com/0/1196225495304457/1196225495304485/f

**How:**
- Update the media queries to display the menu starting on resolutions lower or equal than 1024px
- Use the correct font-family in the dc-dropdown and dc-collapser

#### Media:
https://www.loom.com/share/f60373e49ce8402ba99dfbe6210cf16d
