### PR TITLE
Refactor dropdown and header component

### DIFF
--- a/packages/dropdown-component/package.json
+++ b/packages/dropdown-component/package.json
@@ -9,7 +9,7 @@
   "types": "dist/custom-elements/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/dropdown-component/dropdown-component.js",
+  "unpkg": "dist/dropdown-component/dropdown-component.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/packages/dropdown-component/readme.md
+++ b/packages/dropdown-component/readme.md
@@ -59,7 +59,7 @@ The first step for all three of these strategies is to [publish to NPM](https://
 
 ### Script tag
 
-- Put a script tag similar to this `<script src='https://unpkg.com/@debtcollective/dc-dropdown@latest/dist/popup-component/popup-component.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script src='https://unpkg.com/@debtcollective/dc-dropdown-component@latest/dist/dropdown-component/dropdown-component.esm.js'></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules

--- a/packages/header-component/README.md
+++ b/packages/header-component/README.md
@@ -14,6 +14,14 @@ Stencil components are just Web Components, so they work in any major framework 
 
 ## Getting Started
 
+Currently, due to an issue with lerna and the local dependencies, in order to run this component locally you will need to do the following:
+
+```bash
+yarn remove @debtcollective/dc-dropdown-component
+yarn add @debtcollective/dc-dropdown-component
+```
+
+
 ```bash
 yarn install
 yarn start
@@ -75,7 +83,7 @@ Alternatively, you can choose to inject your own structure by doing something li
 ### Script tag
 
 - [Publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages)
-- Put a script tag similar to this `<script src='https://unpkg.com/dc-dropdown@0.0.1/dist/dropdown.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script src='https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.js'></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -9,7 +9,7 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/header-component/header-component.js",
+  "unpkg": "dist/header/header.js",
   "files": [
     "dist/",
     "loader/"
@@ -25,7 +25,7 @@
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "dependencies": {
-    "@debtcollective/dc-dropdown-component": "^1.5.0",
+    "@debtcollective/dc-dropdown-component": "^1.6.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -42,7 +42,7 @@
 /* Logo */
 :host .logo {
   /* 2.667em is the size of logo within the community */
-  height: 2.667em;
+  height: 2.667rem;
   position: relative;
   width: auto;
 }
@@ -85,8 +85,8 @@
 :host .avatar {
   border-radius: 50%;
   /* Match exactly community dimensions */
-  width: 2.1333em;
-  height: 2.1333em;
+  width: 2.1333rem;
+  height: 2.1333rem;
 }
 
 :host #current-user {
@@ -95,9 +95,9 @@
   align-items: center;
   justify-content: center;
   /* Make the profile picture mirror community one */
-  width: 2.2857em;
-  height: 2.2857em;
-  padding: 0.2143em;
+  width: 2.2857rem;
+  height: 2.2857rem;
+  padding: 0.2143rem;
   padding-right: 0;
   cursor: pointer;
   outline: none;
@@ -112,7 +112,7 @@
 
 :host .session-items .material-icons {
   font-size: 1.25rem;
-  padding: 0.2143em;
+  padding: 0.2143rem;
   text-decoration: none;
   cursor: pointer;
 }

--- a/packages/header-component/src/components/dc-header/dc-user-items.css
+++ b/packages/header-component/src/components/dc-header/dc-user-items.css
@@ -18,11 +18,11 @@
   border-radius: 10px;
   color: #fff;
   display: inline-block;
-  font-size: .7579em;
+  font-size: .7579rem;
   font-weight: normal;
   left: -2px;
   line-height: 1;
-  padding: 0.21em 0.42em;
+  padding: 0.21rem 0.42rem;
   position: absolute;
   text-align: center;
   top: -4px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,6 +477,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@debtcollective/dc-dropdown-component@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@debtcollective/dc-dropdown-component/-/dc-dropdown-component-1.6.0.tgz#52963d2324939f230b3374243b21b84e2ea8bf84"
+  integrity sha512-NZ0WNHdmdMdMKuInFBDz90Kfv4giTW+rvLeteJ1fPP/59Iod0dUZvTPtkCpaXKd+ptOLP295h6kqJ0k+Ty/dfQ==
+  dependencies:
+    lodash.omit "^4.5.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"


### PR DESCRIPTION
**What:**
- Update the readme files for the dropdown and header component to add the current unpkg link
- Use `rem` instead of `em` to avoid breaking the UI (this occurs in the student debt page, see attachments)

The notifications amount is too big
![image](https://user-images.githubusercontent.com/20747535/96323556-2fddf400-0fe3-11eb-8ccf-a32a69fe68f0.png)

The buttons are too big
![image](https://user-images.githubusercontent.com/20747535/96323581-52700d00-0fe3-11eb-9ef3-738441ded7e1.png)

**Why:**
- Relates to: https://app.asana.com/0/1168997577035609/1198296635707133/f

**How:**
- Replace all `em` for `rem`
- Use the right unpkg inks  in the readme files