### PR TITLE
Fix/dc dropdown dc header

### DIFF
--- a/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.css
+++ b/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.css
@@ -12,6 +12,9 @@
   --main-font: "Libre Franklin", sans-serif;
 
   display: inline-block;
+}
+
+:host * {
   font-family: var(--main-font);
 }
 

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -190,7 +190,7 @@ export class Header {
                   </a>
                 </div>
               ))}
-              <dc-dropdown label="Take Action!" items={TAKE_ACTION_LINKS} />
+              <dc-dropdown class="d-md-flex" label="Take Action!" items={TAKE_ACTION_LINKS} />
             </slot>
           </nav>
           <div class="session-items">
@@ -217,6 +217,7 @@ export class Header {
                 </a>
               </div>
             ))}
+            <dc-collapser label="Take Action!" items={JSON.parse(TAKE_ACTION_LINKS)} />
           </slot>
         </dc-menu>
       </Host>


### PR DESCRIPTION
**What:**
- Fix font family for the dropdown-component
- Hide dc-dropdown in the header component when the screen resolution is lower than 768px
- Display the dc-collapser in the dc-menu for the header-component

**Why:**
Relates to: https://app.asana.com/0/1168997577035609/1198296635707133/f

**How:**
- Change the font family with the * selector in the dc-dropdown
- Hide dc-dropdown in small screens in the header component
- use dc-collapser in the header-component

#### Media
https://www.loom.com/share/6a824172190e478aa5de6165defd94c5
