### PR TITLE
Header shadow dom drop

### DIFF
--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -26,7 +26,7 @@
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
   "dependencies": {
-    "@debtcollective/dc-dropdown-component": "^1.6.1",
+    "@debtcollective/dc-dropdown-component": "^1.6.2",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -10,7 +10,7 @@ export namespace Components {
         /**
           * Items to be displayed in the collapser
          */
-        "items": Array<{ text: string; href: string, target?: string }>;
+        "items": string;
         /**
           * label for the collapser nav item
          */
@@ -135,7 +135,7 @@ declare namespace LocalJSX {
         /**
           * Items to be displayed in the collapser
          */
-        "items"?: Array<{ text: string; href: string, target?: string }>;
+        "items"?: string;
         /**
           * label for the collapser nav item
          */

--- a/packages/header-component/src/components/dc-header/dc-collapser.css
+++ b/packages/header-component/src/components/dc-header/dc-collapser.css
@@ -1,29 +1,32 @@
-:host .collapser-items {
+dc-collapser .collapser-items {
   left: -80%;
   top: 2rem;
   border-radius: 0 0.5rem 0.5rem;
   background-color: var(--main-bg-color);
+  margin-top: .5rem;
+  margin-left: 1rem;
+  list-style: none;
   padding: 0;
   cursor: pointer;
 }
 
-:host .collapser-items.open {
+dc-collapser .collapser-items.open {
   display: block;
 }
 
-:host .collapser-items.hidden {
+dc-collapser .collapser-items.hidden {
   display: none;
 }
 
-:host .collapser-item {
+dc-collapser .collapser-item {
   margin-bottom: 0.75rem;
 }
 
-:host .collapser-items .collapser-item:hover .collapser-item-text  {
+dc-collapser .collapser-items .collapser-item:hover .collapser-item-text  {
   color: var(--brand-color);
 }
 
-:host .collapser-items .collapser-item .collapser-item-text {
+dc-collapser .collapser-items .collapser-item .collapser-item-text {
   color: var(--disabled-text-color);
   font-size: 0.875rem;
   font-weight: 600;

--- a/packages/header-component/src/components/dc-header/dc-collapser.tsx
+++ b/packages/header-component/src/components/dc-header/dc-collapser.tsx
@@ -20,7 +20,7 @@ export class Collapser {
   /**
    * Items to be displayed in the collapser
    */
-  @Prop() items: Array<{ text: string; href: string, target?: string }>;
+  @Prop() items: string;
   
   @State() open: boolean;
 
@@ -29,6 +29,9 @@ export class Collapser {
   }
 
   render() {
+    //TODO: @Watch approach seems to not work correctly
+    const _items = JSON.parse(this.items)
+
     return (
       <div class="nav-item">
         <button
@@ -42,7 +45,7 @@ export class Collapser {
         </button>
         <ul class={`collapser-items ${this.open ? "open " : "hidden"}`}>
           {
-            this?.items?.map(item => (
+            _items?.map(item => (
               <li class="collapser-item">
                 <a class="collapser-item-text" {...omit(item, ['text'])}>
                   {item.text}

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -1,4 +1,4 @@
-:host {
+dc-header {
   --brand-color: #ff4630;
   --button-color: #ff4630;
   --button-hover-color: #ee2812;
@@ -12,16 +12,16 @@
   --main-font: "Libre Franklin", sans-serif;
 }
 
-:host * {
+dc-header * {
   font-family: var(--main-font);
 }
 
-:host a {
+dc-header a {
   text-decoration: none;
 }
 
 /* Container */
-:host .header {
+dc-header .header {
   -webkit-backface-visibility: hidden;
   align-items: center;
   backface-visibility: hidden;
@@ -40,31 +40,31 @@
 }
 
 /* Logo */
-:host .logo {
+dc-header .logo {
   /* 2.667em is the size of logo within the community */
   height: 2.667rem;
   position: relative;
   width: auto;
 }
 
-:host .logo-link {
+dc-header .logo-link {
   display: flex;
   align-items: center;
   margin-right: 1rem;
 }
 
 /* Navigation */
-:host .nav {
+dc-header .nav {
   align-items: center;
   display: flex;
   flex: 1;
 }
 
-:host .nav-item {
+dc-header .nav-item {
   padding: 0 0.625rem;
 }
 
-:host .nav-link {
+dc-header .nav-link {
   color: var(--text-color);
   font-size: var(--font-size);
   font-weight: 600;
@@ -73,23 +73,23 @@
   transition: color 0.216s ease;
 }
 
-:host .nav-link:visited {
+dc-header .nav-link:visited {
   color: var(--text-color);
 }
 
-:host .nav-link:hover {
+dc-header .nav-link:hover {
   color: var(--brand-color);
 }
 
 /* Avatar */
-:host .avatar {
+dc-header .avatar {
   border-radius: 50%;
   /* Match exactly community dimensions */
   width: 2.1333rem;
   height: 2.1333rem;
 }
 
-:host #current-user {
+dc-header #current-user {
   position: relative;
   display: flex;
   align-items: center;
@@ -104,30 +104,30 @@
 }
 
 /* Header session items */
-:host .session-items {
+dc-header .session-items {
   display: flex;
   align-items: center;
   margin-left: 1rem;
 }
 
-:host .session-items .material-icons {
+dc-header .session-items .material-icons {
   font-size: 1.25rem;
   padding: 0.2143rem;
   text-decoration: none;
   cursor: pointer;
 }
 
-:host .avatar {
+dc-header .avatar {
   margin-left: .5rem;
 }
 
-:host .session-links {
+dc-header .session-links {
   display: flex;
   align-items: center;
 }
 
 /* Buttons */
-:host .btn {
+dc-header .btn {
   align-items: center;
   border-radius: 0.25rem;
   cursor: pointer;
@@ -137,32 +137,32 @@
   transition: background 0.216s ease, color 0.216s ease;
 }
 
-:host .btn-outline {
+dc-header .btn-outline {
   background: transparent;
   border: 0.0625rem solid var(--text-color);
   color: var(--text-color);
 }
 
-:host .btn-outline:hover {
+dc-header .btn-outline:hover {
   background: var(--outline-button-hover-color);
 }
 
-:host .btn-primary {
+dc-header .btn-primary {
   background: var(--button-color);
   border: 0.0625rem solid var(--button-color);
   color: #fff;
 }
 
-:host .btn-primary:hover {
+dc-header .btn-primary:hover {
   border: 0.0625rem solid var(--button-hover-color);
   background: var(--button-hover-color);
 }
 
-:host .header .btn + .btn {
+dc-header .header .btn + .btn {
   margin-left: 0.4375rem;
 }
 
-:host .btn-transparent {
+dc-header .btn-transparent {
   background: none;
   border: none;
   display: flex;
@@ -176,28 +176,28 @@
 }
 
 /* Media queries utils */
-:host .d-md-flex {
+dc-header .d-md-flex {
   display: none;
 }
 
 @media (min-width: 1024px) {
-  :host .d-md-flex {
+  dc-header .d-md-flex {
     display: flex;
   }
 }
 
-:host .d-md-none {
+dc-header .d-md-none {
   display: flex;
 }
 
 @media (min-width: 1024px) {
-  :host .d-md-none {
+  dc-header .d-md-none {
     display: none;
   }
 }
 
 /* Make sure material-icons class have its effect */
-:host .material-icons {
+dc-header .material-icons {
   color: var(--text-color);
   font-family: "Material Icons";
   font-weight: normal;

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -8,9 +8,9 @@ import {
   Host,
   Listen,
   Event,
-  EventEmitter
+  EventEmitter,
 } from "@stencil/core";
-import omit from 'lodash.omit';
+import omit from "lodash.omit";
 import { syncCurrentUser } from "../../services/session";
 import "./dc-menu";
 import "./dc-user-items";
@@ -32,27 +32,26 @@ type User = {
 // dc-dropdown.items accepts strings
 const TAKE_ACTION_LINKS = JSON.stringify([
   {
-    text: 'Events',
-    href: 'https://community.debtcollective.org/calendar',
-    target: '_blank'
+    text: "Events",
+    href: "https://community.debtcollective.org/calendar",
+    target: "_blank",
   },
   {
-    text: 'Student Debt Strike',
-    href: 'https://strike.debtcollective.org',
-    target: '_blank'
+    text: "Student Debt Strike",
+    href: "https://strike.debtcollective.org",
+    target: "_blank",
   },
   {
-    text: 'Dispute Your Debt',
-    href: 'https://tools.debtcollective.org/',
-    target: '_blank'
+    text: "Dispute Your Debt",
+    href: "https://tools.debtcollective.org/",
+    target: "_blank",
   },
-])
+]);
 
 @Component({
   assetsDirs: ["assets"],
   tag: "dc-header",
   styleUrl: "dc-header.css",
-  shadow: true
 })
 export class Header {
   /**
@@ -109,11 +108,12 @@ export class Header {
    * TODO: Cannot find name User on EventEmitter<User>
    */
   @Event({
-    eventName: 'userSynced',
+    eventName: "userSynced",
     composed: true,
     cancelable: true,
     bubbles: true,
-  }) userSynced: EventEmitter;
+  })
+  userSynced: EventEmitter;
 
   /**
    * Logo image
@@ -124,7 +124,7 @@ export class Header {
   /**
    * Host the value of "links" parsed to an actual Array
    */
-  private _links: Array<{ text: string; href: string, target?: string }>;
+  private _links: Array<{ text: string; href: string; target?: string }>;
 
   @Watch("links")
   linksDidChangeHandler(newValue) {
@@ -149,7 +149,7 @@ export class Header {
     const user = await syncCurrentUser(this.community);
 
     this.user = user;
-    this.userSynced.emit(user)
+    this.userSynced.emit(user);
   }
 
   componentWillLoad() {
@@ -158,7 +158,7 @@ export class Header {
   }
 
   render() {
-    const linksToRender = this._links
+    const linksToRender = this._links;
 
     return (
       <Host>
@@ -176,29 +176,43 @@ export class Header {
           >
             <img
               class="logo"
-              src={this.logosmall || getAssetPath(`./assets/${this._logoSmall}`)}
+              src={
+                this.logosmall || getAssetPath(`./assets/${this._logoSmall}`)
+              }
               alt="The Debtcollective"
             />
             <span class="material-icons ml-1">keyboard_arrow_right</span>
           </button>
           <nav class="nav">
             <slot name="header">
-              {linksToRender.map(link => (
-                <div class="nav-item d-md-flex">
-                  <a class="nav-link" {...omit(link, ['text'])}>
-                    {link.text}
-                  </a>
-                </div>
-              ))}
-              <dc-dropdown class="d-md-flex" label="Take Action!" items={TAKE_ACTION_LINKS} />
+              <div class="nav">
+                {linksToRender.map((link) => (
+                  <div class="nav-item d-md-flex">
+                    <a class="nav-link" {...omit(link, ["text"])}>
+                      {link.text}
+                    </a>
+                  </div>
+                ))}
+              </div>
             </slot>
+            <dc-dropdown
+              class="d-md-flex"
+              label="Take Action!"
+              items={TAKE_ACTION_LINKS}
+            />
           </nav>
           <div class="session-items">
             {this.user ? (
               <dc-user-items user={this.user} community={this.community} />
             ) : (
               <div class="session-links">
-                <a href={loginURL({ community: this.community, host: this.host })} class="btn btn-outline">
+                <a
+                  href={loginURL({
+                    community: this.community,
+                    host: this.host,
+                  })}
+                  class="btn btn-outline"
+                >
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
                 <a href={this.donateurl} class="btn btn-primary">
@@ -210,15 +224,15 @@ export class Header {
         </header>
         <dc-menu open={this.isMenuOpen} logo={this.logo}>
           <slot name="menu">
-            {linksToRender.map(link => (
+            {linksToRender.map((link) => (
               <div class="nav-item">
-                <a class="nav-link" {...omit(link, ['text'])}>
+                <a class="nav-link" {...omit(link, ["text"])}>
                   {link.text}
                 </a>
               </div>
             ))}
-            <dc-collapser label="Take Action!" items={JSON.parse(TAKE_ACTION_LINKS)} />
           </slot>
+          <dc-collapser label="Take Action!" items={TAKE_ACTION_LINKS} />
         </dc-menu>
       </Host>
     );

--- a/packages/header-component/src/components/dc-header/dc-menu.css
+++ b/packages/header-component/src/components/dc-header/dc-menu.css
@@ -1,12 +1,12 @@
-:host .menu-container.open .menu {
+dc-menu .menu-container.open .menu {
   transform: translate3d(0, 0, 0);
 }
 
-:host .menu-container.hidden .menu {
+dc-menu .menu-container.hidden .menu {
   transform: translate3d(-100%, 0, 0);
 }
 
-:host .menu {
+dc-menu .menu {
   -webkit-backface-visibility: hidden;
   align-items: flex-start;
   backface-visibility: hidden;
@@ -26,7 +26,7 @@
   z-index: var(--z-index);
 }
 
-:host .menu-cloak {
+dc-menu .menu-cloak {
   height: 100vh;
   width: 100vw;
   position: fixed;
@@ -37,15 +37,15 @@
   z-index: var(--z-index);
 }
 
-:host .menu-container.open .menu-cloak {
+dc-menu .menu-container.open .menu-cloak {
   display: block;
 }
 
-:host .menu-container.hidden .menu-cloak {
+dc-menu .menu-container.hidden .menu-cloak {
   display: none;
 }
 
-:host .menu-close {
+dc-menu .menu-close {
   align-items: center;
   background: rgba(57,57,57,0.07);
   border-radius: 50%;
@@ -54,11 +54,11 @@
   padding: 0.5rem;
 }
 
-:host .menu-logo {
+dc-menu .menu-logo {
   width: 50%;
 }
 
-:host .nav-header {
+dc-menu .nav-header {
   align-items: center;
   border-bottom: 0.0625rem solid #e8e8e8;
   box-sizing: border-box;
@@ -69,6 +69,6 @@
   width: 100%;
 }
 
-:host .menu-nav .nav-item {
+dc-menu .menu-nav .nav-item {
   margin-bottom: 1rem;
 }

--- a/packages/header-component/src/components/dc-header/dc-user-dropdown.css
+++ b/packages/header-component/src/components/dc-header/dc-user-dropdown.css
@@ -1,8 +1,8 @@
-:host .user-dropdown-container {
+dc-user-dropdown .user-dropdown-container {
   position: relative;
 }
 
-:host .user-dropdown-items {
+dc-user-dropdown .user-dropdown-items {
   position: absolute;
   top: 2.5rem;
   right: 0;
@@ -14,19 +14,19 @@
   box-shadow: 0 0 0.5rem rgba(37, 40, 43, 0.12);
 }
 
-:host .user-dropdown-items.open {
+dc-user-dropdown .user-dropdown-items.open {
   opacity: 1;
   transition: opacity 0.1s ease-in;
   visibility: visible;
   list-style: none;
 }
 
-:host .user-dropdown-items.hidden {
+dc-user-dropdown .user-dropdown-items.hidden {
   visibility: hidden;
   opacity: 0;
 }
 
-:host .user-dropdown-items .user-dropdown-item {
+dc-user-dropdown .user-dropdown-items .user-dropdown-item {
   display: flex;
   align-items: center;
   justify-content: start;
@@ -37,21 +37,21 @@
   font-weight: 600;
 }
 
-:host .user-dropdown-items .user-dropdown-item:first-child {
+dc-user-dropdown .user-dropdown-items .user-dropdown-item:first-child {
   justify-content: space-between;
 }
 
-:host .user-dropdown-items .user-dropdown-item:last-child {
+dc-user-dropdown .user-dropdown-items .user-dropdown-item:last-child {
   width: 100%;
 }
 
-:host .user-dropdown-items .user-dropdown-item:hover, :host .user-dropdown-items .user-dropdown-item:focus {
+dc-user-dropdown .user-dropdown-items .user-dropdown-item:hover, dc-user-dropdown .user-dropdown-items .user-dropdown-item:focus {
   background-color: rgba(255, 70, 48, 0.1);
   transition: background-color 0.1s ease-in;
   color: var(--brand-color);
 }
 
-:host .user-dropdown-items .user-dropdown-item .user-dropdown-item-description {
+dc-user-dropdown .user-dropdown-items .user-dropdown-item .user-dropdown-item-description {
   font-size: 0.75rem;
   line-height: 1rem;
   color: var(--text-color);

--- a/packages/header-component/src/components/dc-header/dc-user-items.css
+++ b/packages/header-component/src/components/dc-header/dc-user-items.css
@@ -1,18 +1,18 @@
-:host .session-user-items {
+dc-user-items .session-user-items {
   display: flex;
   align-items: center;
 }
 
-:host .notification-link {
+dc-user-items .notification-link {
   margin-left: .5rem;
 }
 
 /* Notifications */
-:host .notification-icon {
+dc-user-items .notification-icon {
   position: relative;
 }
 
-:host .badge-notification {
+dc-user-items .badge-notification {
   /* Mirror community badge  */
   background: #bdbdbd;
   border-radius: 10px;
@@ -30,6 +30,6 @@
   z-index: 1;
 }
 
-:host .unread-notifications {
+dc-user-items .unread-notifications {
   background-color: #6cf;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,6 +477,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@debtcollective/dc-dropdown-component@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@debtcollective/dc-dropdown-component/-/dc-dropdown-component-1.6.2.tgz#088bc63b53c0e7c0e8415fed4640a916b0a2d55c"
+  integrity sha512-xX2Am7UlRlQ+upRyGY182+ktO4IUWwKK8X0gMGxOQJHZKPitOYYGbcNMjNH47vCHV6eJQpfXcGH+VwHCDxJshg==
+  dependencies:
+    lodash.omit "^4.5.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"


### PR DESCRIPTION
**What:**
Allow to better use `<slot />` api by allowing passed children to be styled

**Why:**
relates to the need to render `gatsby-links` within some links on the header

**How:**
- Remove the `:host` directive and use the tag name
- Remove the "shadow DOM" flag
- Extract the "Take action" links to outside of the `<slot />` so they will be always shown

**Media:**
https://www.loom.com/share/5e66a7eb51c740f78900e6d5cf3b6b0b
