### PR TITLE
Make header logo route to the home page

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -29,6 +29,8 @@ type User = {
   unread_high_priority_notifications: number;
 };
 
+export const HOME_PAGE_LINK = "https://debtcollective.org/";
+
 // dc-dropdown.items accepts strings
 const TAKE_ACTION_LINKS = JSON.stringify([
   {
@@ -163,7 +165,7 @@ export class Header {
     return (
       <Host>
         <header class="header">
-          <a class="logo-link d-md-flex" href="/">
+          <a class="logo-link d-md-flex" href={HOME_PAGE_LINK}>
             <img
               class="logo"
               src={this.logo || getAssetPath(`./assets/${this._logo}`)}

--- a/packages/header-component/src/components/dc-header/dc-menu.tsx
+++ b/packages/header-component/src/components/dc-header/dc-menu.tsx
@@ -6,6 +6,7 @@ import {
   Prop,
   getAssetPath
 } from "@stencil/core";
+import { HOME_PAGE_LINK } from "./dc-header";
 
 @Component({
   assetsDirs: ["assets"],
@@ -40,7 +41,7 @@ export class Menu {
         <div class="menu-cloak" onClick={this.toggleMenuHandler.bind(this)} />
         <div class="menu">
           <div class="nav-header">
-            <a href="/">
+            <a href={HOME_PAGE_LINK}>
               <img
                 class="menu-logo"
                 src={this.logo || getAssetPath(`./assets/${this._logo}`)}


### PR DESCRIPTION
**What:**
Make header logo route to the home page

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1198498074643140/f

**How:**
Using a variable to set the home page link and set it in the logo anchors

#### Media
https://www.loom.com/share/c45a296733d34f5c881771578e5c685a