### PR TITLE
Upgrade stencil version

### DIFF
--- a/packages/dropdown-component/package.json
+++ b/packages/dropdown-component/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@stencil/core": "2.0.3",
+    "@stencil/core": "^2.1.0",
     "prettier": "^2.1.2"
   }
 }

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -30,7 +30,7 @@
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {
-    "@stencil/core": "2.0.3",
+    "@stencil/core": "^2.1.0",
     "@types/jest": "25.2.3",
     "@types/node": "13.13.21",
     "@types/puppeteer": "2.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,10 +1534,10 @@
   dependencies:
     typescript "3.9.7"
 
-"@stencil/core@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.0.3.tgz#8719d3131362076a35b7a7c865de4720766f3f47"
-  integrity sha512-d4qLDN7HKwJEK+ljhknD8azpM4bF49Dv7h5yG3RF+SPo8uozDq3p5ZNj1MgZoRgzh04kXNyG/MKnD8H2QN5YVw==
+"@stencil/core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.1.0.tgz#3525c9e36da775bc3c5eb01b2e070be400386c8e"
+  integrity sha512-fvDBIddSx/oU4kQvHPqjw4WG3s7uBvmlhez69oEc7Z04yhWqZivyLYdQ0XWN/MS/KgKv6JTcWmMrGH+4IzItWQ==
 
 "@stencil/sass@1.3.2":
   version "1.3.2"


### PR DESCRIPTION
**What:**
Upgrade stencil version to 2.1.0

**Why:**
To keep dependencies up to date

**How:**
Upgrading dependencies locally