### PR TITLE
Update node version to 14.5.0 in the circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     working_directory: ~/packages
     docker:
-      - image: circleci/node:12.18.4-browsers
+      - image: circleci/node:14.5.0-browsers
     steps:
       - checkout
       - restore_cache:
@@ -27,7 +27,7 @@ jobs:
   publish:
     working_directory: ~/packages
     docker:
-      - image: circleci/node:12.18.4-browsers
+      - image: circleci/node:14.5.0-browsers
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
**What:**
Update node version to 14.5.0 in the circle CI config

**Why:**
Pipeline failed: https://app.circleci.com/pipelines/github/debtcollective/packages/514/workflows/82433669-3585-4591-bcba-e69d4a6cc223/jobs/604

**How:**
Updating the circle ci configuration file
