### PR TITLE
Avoid exporting variables from the dc-header file

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -29,7 +29,7 @@ type User = {
   unread_high_priority_notifications: number;
 };
 
-export const HOME_PAGE_LINK = "https://debtcollective.org/";
+const HOME_PAGE_LINK = "https://debtcollective.org/";
 
 // dc-dropdown.items accepts strings
 const TAKE_ACTION_LINKS = JSON.stringify([

--- a/packages/header-component/src/components/dc-header/dc-menu.tsx
+++ b/packages/header-component/src/components/dc-header/dc-menu.tsx
@@ -6,7 +6,8 @@ import {
   Prop,
   getAssetPath
 } from "@stencil/core";
-import { HOME_PAGE_LINK } from "./dc-header";
+
+const HOME_PAGE_LINK = "https://debtcollective.org/";
 
 @Component({
   assetsDirs: ["assets"],


### PR DESCRIPTION
**What:**
Avoid exporting variables from the dc-header file

**Why:**
Related to: https://app.circleci.com/pipelines/github/debtcollective/packages/516/workflows/830d7651-6c92-4340-95fc-4f0de5a2e7e2/jobs/607

**How:**
- Remove the export from the `HOME_PAGE_LINK` and add the variable in the `dc-menu` and `dc-header`
