### PR TITLE
fix(header-component): align user items correctly

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-user-items.css
+++ b/packages/header-component/src/components/dc-header/dc-user-items.css
@@ -1,4 +1,4 @@
-dc-user-items .session-user-items {
+dc-user-items {
   display: flex;
   align-items: center;
 }

--- a/packages/header-component/src/components/dc-header/dc-user-items.tsx
+++ b/packages/header-component/src/components/dc-header/dc-user-items.tsx
@@ -31,7 +31,7 @@ export class Menu {
     } = this.user;
 
     return (
-      <Host class="session-user-items">
+      <Host>
         <a
           class="notification-link"
           href={preffixCommunityURL(


### PR DESCRIPTION
**What:**
Align user items correctly

**Why:**
Closes: https://app.asana.com/0/1159164196409156/1198945902875077/f

**How:**
Removing the classname from the `Host` stencil component and applying the style directly to the dc-user-items tag

#### Media
https://www.loom.com/share/c5ecf6866e3749a08f5bbae07c04e745