### PR TITLE
Avoid to go to mobile elements with tab in desktop screens

### DIFF
--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -193,6 +193,7 @@ dc-header .d-md-none {
 @media (min-width: 1024px) {
   dc-header .d-md-none {
     display: none;
+    visibility: hidden;
   }
 }
 

--- a/packages/header-component/src/components/dc-header/dc-menu.css
+++ b/packages/header-component/src/components/dc-header/dc-menu.css
@@ -1,9 +1,11 @@
 dc-menu .menu-container.open .menu {
   transform: translate3d(0, 0, 0);
+  visibility: visible;
 }
 
 dc-menu .menu-container.hidden .menu {
   transform: translate3d(-100%, 0, 0);
+  visibility: hidden;
 }
 
 dc-menu .menu {


### PR DESCRIPTION
**What:**
Avoid going to mobile elements with the tab on desktop screens

**Why:**
Closes: https://app.asana.com/0/1159164196409156/1198926861866064/f

**How:**
Adding `visibility: hidden` when the menu is open. This will avoid that the user can get to the mobile menu on desktop devices

### Media
https://www.loom.com/share/ff2ea93140db494b8050bee6415e9553

