### PR TITLE
Refactor/packages unpkg route

### DIFF
--- a/packages/dropdown-component/package.json
+++ b/packages/dropdown-component/package.json
@@ -10,7 +10,7 @@
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/dropdown-component/dropdown-component.esm.js",
+  "unpkg": "@latest/dist/dropdown-component/dropdown-component.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/packages/dropdown-component/readme.md
+++ b/packages/dropdown-component/readme.md
@@ -59,7 +59,7 @@ The first step for all three of these strategies is to [publish to NPM](https://
 
 ### Script tag
 
-- Put a script tag similar to this `<script src='https://unpkg.com/@debtcollective/dc-dropdown-component@latest/dist/dropdown-component/dropdown-component.esm.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script type="module" src="https://unpkg.com/@debtcollective/dc-dropdown-component@latest/dist/dropdown-component/dropdown-component.esm.js"></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules

--- a/packages/header-component/README.md
+++ b/packages/header-component/README.md
@@ -83,7 +83,7 @@ Alternatively, you can choose to inject your own structure by doing something li
 ### Script tag
 
 - [Publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages)
-- Put a script tag similar to this `<script src='https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script type="module" src="https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.esm.js"></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules

--- a/packages/header-component/package.json
+++ b/packages/header-component/package.json
@@ -10,7 +10,7 @@
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/header/header.js",
+  "unpkg": "@latest/dist/header/header.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/packages/popup-component/package.json
+++ b/packages/popup-component/package.json
@@ -9,7 +9,7 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/popup-component/popup-component.js",
+  "unpkg": "@latest/dist/popup-component/popup-component.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/packages/popup-component/readme.md
+++ b/packages/popup-component/readme.md
@@ -56,7 +56,7 @@ Instead, use a prefix that fits your company or any name for a group of related 
 ### Script tag
 
 - [Publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages)
-- Put a script tag similar to this `<script src='https://unpkg.com/dc-dropdown@0.0.1/dist/dropdown.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script type="module" src="https://unpkg.com/dc-dropdown@latest/dist/popup-component/popup-component.esm.js"></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules


### PR DESCRIPTION
**What:**
Update the `unpkg` property on package.json to define the default route to load component

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1198910117742141/f

**How:**
Updating both package.json and readme.md of each web component

