### PR TITLE
Header donation

### DIFF
--- a/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.css
+++ b/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.css
@@ -35,7 +35,8 @@
   color: var(--text-color);
 }
 
-:host .nav-link:hover {
+:host .nav-link:hover,
+:host .nav-link:hover .material-icons {
   color: var(--brand-color);
 }
 

--- a/packages/header-component/README.md
+++ b/packages/header-component/README.md
@@ -21,7 +21,6 @@ yarn remove @debtcollective/dc-dropdown-component
 yarn add @debtcollective/dc-dropdown-component
 ```
 
-
 ```bash
 yarn install
 yarn start
@@ -79,6 +78,16 @@ Alternatively, you can choose to inject your own structure by doing something li
 ```
 
 > NOTE: be aware of not adding the latest "/" on the url props such as host and community
+
+if you need to use router link within the donate button you should set `donateurl` to falsy value so the custom donate button will render alone
+
+```jsx
+<dc-header donateurl="">
+  <div slot="donate">
+    <Link class="btn-donate">Donate</Link>
+  </div>
+</dc-header>
+```
 
 ### Script tag
 

--- a/packages/header-component/src/components/dc-header/dc-collapser.css
+++ b/packages/header-component/src/components/dc-header/dc-collapser.css
@@ -10,11 +10,11 @@ dc-collapser .collapser-items {
   cursor: pointer;
 }
 
-dc-collapser .collapser-items.open {
+dc-collapser.open .collapser-items {
   display: block;
 }
 
-dc-collapser .collapser-items.hidden {
+dc-collapser.collapsed .collapser-items {
   display: none;
 }
 
@@ -22,7 +22,7 @@ dc-collapser .collapser-item {
   margin-bottom: 0.75rem;
 }
 
-dc-collapser .collapser-items .collapser-item:hover .collapser-item-text  {
+dc-collapser .collapser-items .collapser-item:hover .collapser-item-text {
   color: var(--brand-color);
 }
 

--- a/packages/header-component/src/components/dc-header/dc-collapser.css
+++ b/packages/header-component/src/components/dc-header/dc-collapser.css
@@ -22,7 +22,8 @@ dc-collapser .collapser-item {
   margin-bottom: 0.75rem;
 }
 
-dc-collapser .collapser-items .collapser-item:hover .collapser-item-text {
+dc-collapser .collapser-items .collapser-item:hover .collapser-item-text,
+dc-collapser .nav-link:hover .material-icons {
   color: var(--brand-color);
 }
 

--- a/packages/header-component/src/components/dc-header/dc-collapser.tsx
+++ b/packages/header-component/src/components/dc-header/dc-collapser.tsx
@@ -1,15 +1,10 @@
-import {
-  Component,
-  h,
-  State,
-  Prop,
-} from "@stencil/core";
-import omit from 'lodash.omit';
+import { Component, h, State, Prop, Host } from "@stencil/core";
+import omit from "lodash.omit";
 
 @Component({
   assetsDirs: ["assets"],
   tag: "dc-collapser",
-  styleUrl: "dc-collapser.css"
+  styleUrl: "dc-collapser.css",
 })
 export class Collapser {
   /**
@@ -21,7 +16,7 @@ export class Collapser {
    * Items to be displayed in the collapser
    */
   @Prop() items: string;
-  
+
   @State() open: boolean;
 
   toggleCollapser() {
@@ -30,32 +25,31 @@ export class Collapser {
 
   render() {
     //TODO: @Watch approach seems to not work correctly
-    const _items = JSON.parse(this.items)
+    const _items = JSON.parse(this.items);
 
     return (
-      <div class="nav-item">
-        <button
-          class="nav-link btn btn-transparent"
-          onClick={this.toggleCollapser.bind(this)}
-        >
-          {this.label || ''} 
-          <span class="material-icons">
-            {this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-          </span>
-        </button>
-        <ul class={`collapser-items ${this.open ? "open " : "hidden"}`}>
-          {
-            _items?.map(item => (
+      <Host class={`${this.open ? "open " : "collapsed"}`}>
+        <div class="nav-item">
+          <button
+            class="nav-link btn btn-transparent"
+            onClick={this.toggleCollapser.bind(this)}
+          >
+            {this.label || ""}
+            <span class="material-icons">
+              {this.open ? "keyboard_arrow_up" : "keyboard_arrow_down"}
+            </span>
+          </button>
+          <ul class="collapser-items">
+            {_items?.map((item) => (
               <li class="collapser-item">
-                <a class="collapser-item-text" {...omit(item, ['text'])}>
+                <a class="collapser-item-text" {...omit(item, ["text"])}>
                   {item.text}
                 </a>
               </li>
-            ))
-          }
-        </ul>
-      </div>
+            ))}
+          </ul>
+        </div>
+      </Host>
     );
   }
 }
-  

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -133,11 +133,13 @@ dc-header .session-links {
 }
 
 /* Buttons */
-dc-header .btn {
+dc-header .btn,
+dc-header .btn-donate {
   align-items: center;
   border-radius: 0.25rem;
   cursor: pointer;
   display: flex;
+  font-size: 1rem;
   justify-content: space-between;
   padding: 0.5rem 1rem;
   transition: background 0.216s ease, color 0.216s ease;
@@ -153,19 +155,22 @@ dc-header .btn-outline:hover {
   background: var(--outline-button-hover-color);
 }
 
-dc-header .btn-primary {
+dc-header .btn-primary,
+dc-header .btn-donate {
   background: var(--button-color);
   border: 0.0625rem solid var(--button-color);
   color: #fff;
 }
 
-dc-header .btn-primary:hover {
+dc-header .btn-primary:hover,
+dc-header .btn-donate:hover {
   border: 0.0625rem solid var(--button-hover-color);
   background: var(--button-hover-color);
 }
 
-dc-header .header .btn + .btn {
-  margin-left: 0.4375rem;
+dc-header .header .btn + .btn,
+dc-header .btn-donate {
+  margin-left: 0.5rem;
 }
 
 dc-header .btn-transparent {

--- a/packages/header-component/src/components/dc-header/dc-header.css
+++ b/packages/header-component/src/components/dc-header/dc-header.css
@@ -116,6 +116,14 @@ dc-header .session-items {
   margin-left: 1rem;
 }
 
+dc-header .session-items .with-user {
+  display: flex;
+}
+
+dc-header .session-items .with-user .btn-donate {
+  margin-right: 2rem;
+}
+
 dc-header .session-items .material-icons {
   font-size: 1.25rem;
   padding: 0.2143rem;
@@ -132,6 +140,16 @@ dc-header .session-links {
   align-items: center;
 }
 
+dc-header .session-items .btn-donate {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  dc-header .session-items .btn-donate {
+    display: block;
+  }
+}
+
 /* Buttons */
 dc-header .btn,
 dc-header .btn-donate {
@@ -143,6 +161,11 @@ dc-header .btn-donate {
   justify-content: space-between;
   padding: 0.5rem 1rem;
   transition: background 0.216s ease, color 0.216s ease;
+}
+
+dc-header .btn-donate {
+  display: block;
+  text-align: center;
 }
 
 dc-header .btn-outline {
@@ -169,7 +192,7 @@ dc-header .btn-donate:hover {
 }
 
 dc-header .header .btn + .btn,
-dc-header .btn-donate {
+dc-header .session-items .btn-donate {
   margin-left: 0.5rem;
 }
 

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -205,7 +205,16 @@ export class Header {
           </nav>
           <div class="session-items">
             {this.user ? (
-              <dc-user-items user={this.user} community={this.community} />
+              <div class="with-user">
+                <slot name="donate">
+                  {this.donateurl && (
+                    <a href={this.donateurl} class="btn-donate">
+                      Donate
+                    </a>
+                  )}
+                </slot>
+                <dc-user-items user={this.user} community={this.community} />
+              </div>
             ) : (
               <div class="session-links">
                 <a
@@ -217,15 +226,15 @@ export class Header {
                 >
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
+                <slot name="donate">
+                  {this.donateurl && (
+                    <a href={this.donateurl} class="btn-donate">
+                      Donate
+                    </a>
+                  )}
+                </slot>
               </div>
             )}
-            <slot name="donate">
-              {this.donateurl && (
-                <a href={this.donateurl} class="btn-donate">
-                  Donate
-                </a>
-              )}
-            </slot>
           </div>
         </header>
         <dc-menu open={this.isMenuOpen} logo={this.logo}>
@@ -239,6 +248,15 @@ export class Header {
             ))}
           </slot>
           <dc-collapser label="Take Action!" items={TAKE_ACTION_LINKS} />
+          <div class="menu-footer">
+            <slot name="donate">
+              {this.donateurl && (
+                <a href={this.donateurl} class="btn-donate">
+                  Donate
+                </a>
+              )}
+            </slot>
+          </div>
         </dc-menu>
       </Host>
     );

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -217,11 +217,15 @@ export class Header {
                 >
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
-                <a href={this.donateurl} class="btn btn-primary">
-                  Donate
-                </a>
               </div>
             )}
+            <slot name="donate">
+              {this.donateurl && (
+                <a href={this.donateurl} class="btn-donate">
+                  Donate
+                </a>
+              )}
+            </slot>
           </div>
         </header>
         <dc-menu open={this.isMenuOpen} logo={this.logo}>

--- a/packages/header-component/src/components/dc-header/dc-header.tsx
+++ b/packages/header-component/src/components/dc-header/dc-header.tsx
@@ -226,7 +226,7 @@ export class Header {
                 >
                   <span class="d-md-flex">Member</span>&nbsp;Login
                 </a>
-                <slot name="donate">
+                <slot name="donate-header">
                   {this.donateurl && (
                     <a href={this.donateurl} class="btn-donate">
                       Donate
@@ -249,7 +249,7 @@ export class Header {
           </slot>
           <dc-collapser label="Take Action!" items={TAKE_ACTION_LINKS} />
           <div class="menu-footer">
-            <slot name="donate">
+            <slot name="donate-menu">
               {this.donateurl && (
                 <a href={this.donateurl} class="btn-donate">
                   Donate

--- a/packages/header-component/src/components/dc-header/dc-menu.css
+++ b/packages/header-component/src/components/dc-header/dc-menu.css
@@ -57,7 +57,7 @@ dc-menu .menu-close {
 }
 
 dc-menu .menu-logo {
-  width: 50%;
+  width: 75%;
 }
 
 dc-menu .nav-header {
@@ -73,4 +73,16 @@ dc-menu .nav-header {
 
 dc-menu .menu-nav .nav-item {
   margin-bottom: 1rem;
+  padding: 0 var(--column-gap);
+}
+
+dc-menu .menu-nav {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+dc-menu .menu-footer {
+  margin-top: 1rem;
+  padding: 0 var(--column-gap) 1rem;
 }

--- a/packages/header-component/src/components/dc-header/dc-user-dropdown.css
+++ b/packages/header-component/src/components/dc-header/dc-user-dropdown.css
@@ -66,3 +66,8 @@ dc-user-dropdown .user-dropdown-items .user-dropdown-item .user-dropdown-item-de
   font-size: 0.75rem;
   line-height: 1rem;
 }
+
+dc-user-dropdown .user-dropdown-items .material-icons {
+  padding-left: 0;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
**What:**
Add support to inject custom donation component

**Why:**
relates to the effort of
[Gatsby link for Donate button](https://app.asana.com/0/1168997577035609/1198926861866063)

**How:**
Use the `slot` API from stencil to allow render a custom component whenever the `donateurl` is set to falsy value
_The need of use a donateurl to false comes from the bug that has been addressed with https://github.com/ionic-team/stencil/pull/2650_

**Extras:**
This code will add donate button on mobile and desktop for users and guests, besides some other aesthetics details.

**Media:**
- [Aesthetics updates](https://www.loom.com/share/ae8c37f4e96c4065bb1e9e504e46ae62)
- [How the slot API works with our component](https://www.loom.com/share/ee4d613691fe41feb14e5a345b71a734)
