### PR TITLE
fix: typescript build failing due node_modules

### DIFF
--- a/packages/dropdown-component/tsconfig.json
+++ b/packages/dropdown-component/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/packages/footer-component/src/components/dc-footer/readme.md
+++ b/packages/footer-component/src/components/dc-footer/readme.md
@@ -5,14 +5,18 @@
 <!-- Auto Generated Below -->
 
 
-## Properties
+## Dependencies
 
-| Property | Attribute | Description     | Type     | Default     |
-| -------- | --------- | --------------- | -------- | ----------- |
-| `first`  | `first`   | The first name  | `string` | `undefined` |
-| `last`   | `last`    | The last name   | `string` | `undefined` |
-| `middle` | `middle`  | The middle name | `string` | `undefined` |
+### Used by
 
+ - [dc-footer](.)
+
+### Graph
+```mermaid
+graph TD;
+  dc-footer --> dc-social-media
+  style dc-social-media fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/packages/footer-component/tsconfig.json
+++ b/packages/footer-component/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "skipLibCheck": true
   },
   "include": [
     "src"

--- a/packages/header-component/tsconfig.json
+++ b/packages/header-component/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "skipLibCheck": true
   },
   "include": [
     "src",

--- a/packages/popup-component/tsconfig.json
+++ b/packages/popup-component/tsconfig.json
@@ -14,13 +14,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "skipLibCheck": true
   },
   "include": [
     "src",
     "types/jsx.d.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/packages/union-component/tsconfig.json
+++ b/packages/union-component/tsconfig.json
@@ -26,5 +26,5 @@
     }
   },
   "include": ["src/**/*.js", "src/**/*.jsx","src/**/*.ts","src/**/*.tsx"],
-  "exclude": ["node_modules", "public", ".cache", "src/stories/**/*"]
+  "exclude": ["node_modules", "build", "public", ".cache", "src/stories/**/*"]
 }


### PR DESCRIPTION
**What:** fix typescript build failing due node_modules

**Why:** CI was failing due this https://app.circleci.com/pipelines/github/debtcollective/packages/632/workflows/e0c2a26c-92b2-4b43-a8b6-fa418f8d992b/jobs/746

**How:**

Adding `skipLibCheck: true` to all `tsconfig.json` files. https://stackoverflow.com/a/57653497/536984