### PR TITLE
Use correct link for the donate link

### DIFF
--- a/packages/footer-component/src/components/dc-footer/dc-footer.tsx
+++ b/packages/footer-component/src/components/dc-footer/dc-footer.tsx
@@ -67,7 +67,7 @@ export class DcFooter {
         },
         {
           label: 'Donate',
-          href: '/donate',
+          href: 'https://debtcollective.org/donate/',
         },
       ],
     },


### PR DESCRIPTION
**What:**
Use the correct link for the donate link

**Why:**
The `Donate` link was redirecting to the same host `/donate`, and in the majority of cases this page was not available in the project

**How:**
Replacing the link from the one we use in the home page