### PR TITLE
Allow to toggle chapters dropdown on component usage

### DIFF
--- a/packages/union-component/src/MembershipWidget.tsx
+++ b/packages/union-component/src/MembershipWidget.tsx
@@ -35,9 +35,17 @@ export interface Props {
    * Optional set of classes
    */
   className?: string;
+  /**
+   * Wether or not shown the chapters selection
+   */
+  hasChapterSelection?: boolean;
 }
 
-const MembershipWidget: React.FC<Props> = ({ id, className }) => {
+const MembershipWidget: React.FC<Props> = ({
+  id,
+  className,
+  hasChapterSelection
+}) => {
   const [state, send] = useMachine(membershipMachine);
   const { context: machineContext } = state;
   const { addressInformation, personalInformation } = machineContext;
@@ -152,7 +160,7 @@ const MembershipWidget: React.FC<Props> = ({ id, className }) => {
             lastName: personalInformation.lastName,
             phoneNumber: personalInformation.phoneNumber
           }}
-          hasChapterSelection
+          hasChapterSelection={hasChapterSelection}
           onEditAmount={onEditAmount}
           onSubmit={onSubmitPersonalInfoForm}
           tokenData={getStripeTokenOptions(machineContext)}

--- a/packages/union-component/src/__tests__/MembershipWidget.spec.tsx
+++ b/packages/union-component/src/__tests__/MembershipWidget.spec.tsx
@@ -41,7 +41,7 @@ afterEach(() => {
 test('allows to skip the payment form and complete flow using zero donation selection', async () => {
   const donationAmount = 0;
   const widgetTitle = `Paying $${donationAmount}`;
-  render(<MembershipWidget />);
+  render(<MembershipWidget hasChapterSelection />);
 
   const zeroOptionBtn = screen.getByRole('button', { name: /zero/i });
   userEvent.click(zeroOptionBtn);
@@ -118,7 +118,7 @@ test('allows to skip the payment form and complete flow using zero donation sele
 test('allows to complete flow using an amount donation selection', async () => {
   const donationAmount = 5;
   const widgetTitle = `Paying $${donationAmount}`;
-  render(<MembershipWidget />);
+  render(<MembershipWidget hasChapterSelection />);
 
   // Select an amount
   userEvent.click(
@@ -207,7 +207,7 @@ test('avoid calling membersip api if the stripe token is missing', async () => {
     createToken: jest.fn().mockResolvedValue({ token: { id: null } })
   });
 
-  render(<MembershipWidget />);
+  render(<MembershipWidget hasChapterSelection />);
 
   // Select an amount
   userEvent.click(


### PR DESCRIPTION
**What:**
Allow the usage of the component to define wether to render or not the chapters selection

**Why:**
After https://github.com/debtcollective/home/pull/92 there is a comment in which we presume the chapter dropdown won't be needed, in order to move forward instead waiting for more feedback, the idea is to add the support to enable/disable the dropdown.

**How:**
Add a prop onto the `MembershipWidget` (the only one with chapter dropdown) to allow to define what to do.