### PR TITLE
Enable to navigate through the dropdown component with keyboard arrows

### DIFF
--- a/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.tsx
+++ b/packages/dropdown-component/src/components/dc-dropdown/dc-dropdown.tsx
@@ -1,11 +1,9 @@
-import {
-  Component,
-  h,
-  State,
-  Prop,
-  Listen
-} from '@stencil/core';
+import { Component, h, State, Prop, Listen } from '@stencil/core';
 import omit from 'lodash.omit';
+
+const ESCAPE_KEY_CODE = 27;
+const ARROW_UP_KEY = 'ArrowUp';
+const ARROW_DOWN_KEY = 'ArrowDown';
 
 @Component({
   shadow: true,
@@ -24,6 +22,8 @@ export class DcDropdown {
   @Prop() items: string;
 
   @State() open: boolean;
+
+  @State() itemsRefs: HTMLElement[] = [];
 
   /**
    * Event to detect outside clicks from the dropdown
@@ -44,7 +44,7 @@ export class DcDropdown {
    */
   @Listen('keydown', { target: 'document' })
   handleEscapeKey(event) {
-    if (event.keyCode === 27) this.closeDropdown();
+    if (event.keyCode === ESCAPE_KEY_CODE) this.closeDropdown();
   }
 
   dropdownTrigger!: Node;
@@ -55,37 +55,72 @@ export class DcDropdown {
     this.open = !this.open;
   }
 
+  openDropdown() {
+    this.open = true;
+  }
+
   closeDropdown() {
     this.open = false;
   }
+
+  isKeyDown(key: string): boolean {
+    return key === ARROW_DOWN_KEY;
+  }
+
+  isKeyUp(key: string): boolean {
+    return key === ARROW_UP_KEY;
+  }
+
+  handleArrowDown(index: number) {
+    const firstElement = this.itemsRefs[0];
+    const nextElement = this.itemsRefs[index + 1];
+
+    nextElement ? nextElement.focus() : firstElement.focus();
+  }
+
+  handleArrowUp(index: number) {
+    const indexOfLastElement = this.itemsRefs.length - 1;
+    const lastElement = this.itemsRefs[indexOfLastElement];
+    const nextElement = this.itemsRefs[index - 1];
+
+    nextElement ? nextElement.focus() : lastElement.focus();
+  }
+
+  handleItemKeyDown(event, index) {
+    if (this.isKeyDown(event.key)) this.handleArrowDown(index);
+    if (this.isKeyUp(event.key)) this.handleArrowUp(index);
+  }
+
+  handleLabelKeyDown(event) {
+    const firstElement = this.itemsRefs[0];
+
+    if (this.isKeyDown(event.key)) {
+      this.openDropdown();
+      firstElement.focus();
+    }
+  }
+
   render() {
     //TODO: @Watch approach seems to not work correctly
-    const _items = JSON.parse(this.items)
+    const _items = JSON.parse(this.items);
 
     return (
       <div class="dropdown-container nav-item">
         <button
           class="nav-link btn btn-transparent"
           onClick={this.toggleDropdown.bind(this)}
-          ref={(el) => this.dropdownTrigger = el}
+          ref={el => (this.dropdownTrigger = el)}
+          onKeyDown={this.handleLabelKeyDown.bind(this)}
         >
           {this.label || ''}
-          <span class="material-icons">
-            {this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-          </span>
+          <span class="material-icons">{this.open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}</span>
         </button>
-        <div
-          class={`dropdown-items ${this.open ? "open " : "hidden"}`}
-          onMouseLeave={this.closeDropdown.bind(this)}
-          ref={(el) => this.dropdownItems = el}
-        >
-          {
-            _items?.map(item => (
-              <a class="dropdown-item" {...omit(item, ['text'])}>
-                {item.text}
-              </a>
-            ))
-          }
+        <div class={`dropdown-items ${this.open ? 'open ' : 'hidden'}`} onMouseLeave={this.closeDropdown.bind(this)} ref={el => (this.dropdownItems = el)}>
+          {_items?.map((item, index) => (
+            <a class="dropdown-item" {...omit(item, ['text'])} onKeyDown={event => this.handleItemKeyDown(event, index)} ref={item => (this.itemsRefs[index] = item)}>
+              {item.text}
+            </a>
+          ))}
         </div>
       </div>
     );


### PR DESCRIPTION
**What:**
Enable to navigate through the dropdown component with keyboard arrows

**Why:**
Relates to: https://app.asana.com/0/1159164196409129/1194694158783964/f

**How:**
- Add support to arrow navigation in the dropdown component

#### Media
https://www.loom.com/share/256ce32ff76b40ea87ca952d93d1b843
