### PR TITLE
Fix issue when building for SSR

### DIFF
--- a/packages/union-component/src/api/donation.ts
+++ b/packages/union-component/src/api/donation.ts
@@ -1,3 +1,4 @@
+import { environmentSetup } from '@utils/config';
 import { DEFAULT_ERROR } from '../constants/errors';
 import { DonationMachineContext } from '../machines/donationType';
 
@@ -19,7 +20,7 @@ export const sendDonation = async (context: DonationMachineContext) => {
 
   try {
     recaptchaToken = await grecaptcha.execute(
-      typeof window !== 'undefined' && (window as any).DC_RECAPTCHA_V3_SITE_KEY,
+      environmentSetup.DC_RECAPTCHA_V3_SITE_KEY,
       {
         action: 'donate'
       }
@@ -56,7 +57,7 @@ export const sendDonation = async (context: DonationMachineContext) => {
   };
 
   const response: DonationResponse = await fetch(
-    (window as any).DC_DONATE_API_URL,
+    environmentSetup.DC_DONATE_API_URL,
     {
       method: 'POST',
       credentials: 'include',

--- a/packages/union-component/src/api/membership.ts
+++ b/packages/union-component/src/api/membership.ts
@@ -1,3 +1,4 @@
+import { environmentSetup } from '@utils/config';
 import { DEFAULT_ERROR } from '../constants/errors';
 import { MembershipMachineContext } from '../machines/membershipMachine';
 
@@ -24,7 +25,7 @@ export const sendMembershipDonation = async (
 
   try {
     recaptchaToken = await grecaptcha.execute(
-      (window as any).DC_RECAPTCHA_V3_SITE_KEY,
+      environmentSetup.DC_RECAPTCHA_V3_SITE_KEY,
       {
         action: 'membership'
       }
@@ -52,7 +53,7 @@ export const sendMembershipDonation = async (
   };
 
   const response: DonationResponse = await fetch(
-    (window as any).DC_MEMBERSHIP_API_URL,
+    environmentSetup.DC_MEMBERSHIP_API_URL,
     {
       method: 'POST',
       credentials: 'include',

--- a/packages/union-component/src/components/DonationPaymentForm.tsx
+++ b/packages/union-component/src/components/DonationPaymentForm.tsx
@@ -11,6 +11,7 @@ import DonationDropdown from './DonationDropdown';
 import DonationPhoneInput from './DonationPhoneInput';
 import chapters from '../constants/chapters';
 import { DEFAULT_ERROR } from '../constants/errors';
+import { environmentSetup } from '@utils/config';
 
 export interface Props {
   amount: number;
@@ -87,8 +88,7 @@ const DonationPaymentForm: React.FC<Props> = ({
     setIsSubmitDisabled(!e.complete);
   };
 
-  const stripePublicToken =
-    typeof window !== 'undefined' && (window as any).DC_STRIPE_PUBLIC_TOKEN;
+  const stripePublicToken = environmentSetup.DC_STRIPE_PUBLIC_TOKEN;
 
   return (
     <DonationWizard.Container>

--- a/packages/union-component/src/utils/config.ts
+++ b/packages/union-component/src/utils/config.ts
@@ -1,0 +1,8 @@
+const w = typeof window !== 'undefined' ? (window as any) : {};
+
+export const environmentSetup = {
+  DC_DONATE_API_URL: w.DC_DONATE_API_URL,
+  DC_MEMBERSHIP_API_URL: w.DC_MEMBERSHIP_API_URL,
+  DC_RECAPTCHA_V3_SITE_KEY: w.DC_RECAPTCHA_V3_SITE_KEY,
+  DC_STRIPE_PUBLIC_TOKEN: w.DC_STRIPE_PUBLIC_TOKEN
+};


### PR DESCRIPTION
**What:**
Avoid build error when including component on SSR apps.

**Why:**
Trying to run `yarn build` on home project to check https://github.com/debtcollective/home/pull/92 will lead to error. https://cln.sh/XtBwWL

**How:**
Wrap `window` in a variable that previously check if the object is available to make easier the reference to config variables on applications with server side rendering