### PR TITLE
Facilitate VSCode integration by dropping prettierrc file

### DIFF
--- a/packages/union-component/.prettierrc
+++ b/packages/union-component/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true
+}


### PR DESCRIPTION
**What:**
Make sure VSCode env is ready to go without extra config

**Why:**
When arriving to the project by default the the prettier extension won't be able to look at eslint prettier preferences
