### PR TITLE
Udate machine to meet phone E164

### DIFF
--- a/packages/union-component/src/__tests__/DonationWidget.spec.tsx
+++ b/packages/union-component/src/__tests__/DonationWidget.spec.tsx
@@ -109,8 +109,7 @@ test('send a donation request with all provided information', async () => {
         firstName: cardInformation.firstName,
         lastName: cardInformation.lastName,
         email: cardInformation.email,
-        // Due to library implications packages/union-component/src/__mocks__/react-phone-input-2.tsx
-        phoneNumber: cardInformation.phoneNumber.replace(/\D/g, '')
+        phoneNumber: cardInformation.phoneNumber.replace(/ /g, '')
       },
       donation: {
         message: '',

--- a/packages/union-component/src/__tests__/MembershipWidget.spec.tsx
+++ b/packages/union-component/src/__tests__/MembershipWidget.spec.tsx
@@ -101,8 +101,7 @@ test('allows to skip the payment form and complete flow using zero donation sele
       firstName: personalInformation.firstName,
       lastName: personalInformation.lastName,
       email: personalInformation.email,
-      // Due to library implications packages/union-component/src/__mocks__/react-phone-input-2.tsx
-      phoneNumber: personalInformation.phoneNumber.replace(/\D/g, ''),
+      phoneNumber: personalInformation.phoneNumber.replace(/ /g, ''),
       // As we remove chapter selection
       chapter: undefined
     },
@@ -189,8 +188,7 @@ test('allows to complete flow using an amount donation selection', async () => {
       firstName: personalInformation.firstName,
       lastName: personalInformation.lastName,
       email: personalInformation.email,
-      // Due to library implications packages/union-component/src/__mocks__/react-phone-input-2.tsx
-      phoneNumber: personalInformation.phoneNumber.replace(/\D/g, ''),
+      phoneNumber: personalInformation.phoneNumber.replace(/ /g, ''),
       // As we remove chapter selection
       chapter: undefined
     },

--- a/packages/union-component/src/machines/__tests__/donationMachine.spec.ts
+++ b/packages/union-component/src/machines/__tests__/donationMachine.spec.ts
@@ -127,7 +127,10 @@ test('goes into process donation after filling all information', () => {
 
   expect(machineState.context).toEqual({
     billingInformation,
-    cardInformation,
+    cardInformation: {
+      ...cardInformation,
+      phoneNumber: cardInformation.phoneNumber.replace(/ /g, '')
+    },
     donation: {
       message: '',
       status: '',

--- a/packages/union-component/src/machines/__tests__/membershipMachine.spec.ts
+++ b/packages/union-component/src/machines/__tests__/membershipMachine.spec.ts
@@ -55,7 +55,10 @@ test('goes into process membership state after filling all information', () => {
 
   expect(machineState.context).toEqual({
     addressInformation,
-    personalInformation,
+    personalInformation: {
+      ...personalInformation,
+      phoneNumber: personalInformation.phoneNumber.replace(/ /g, '')
+    },
     api: {
       donation: undefined,
       error: undefined

--- a/packages/union-component/src/machines/donationMachine.ts
+++ b/packages/union-component/src/machines/donationMachine.ts
@@ -191,7 +191,8 @@ const donationWidgetMachine = Machine<
       updatePayeeInformation: assign({
         cardInformation: (context, event) => {
           const { firstName, lastName, email, phoneNumber } = event;
-          return { firstName, lastName, email, phoneNumber };
+          const phoneE164 = `+${phoneNumber.replace(/\D/g, '')}`;
+          return { firstName, lastName, email, phoneNumber: phoneE164 };
         }
       }),
       updatePaymentServices: assign({

--- a/packages/union-component/src/machines/membershipMachine.ts
+++ b/packages/union-component/src/machines/membershipMachine.ts
@@ -113,12 +113,14 @@ const actions = {
   updatePayeeInformation: assign<MembershipMachineContext, PersonalNextEvent>({
     personalInformation: (context, event) => {
       const { firstName, lastName, email, phoneNumber } = event.data;
+      const phoneE164 = `+${phoneNumber.replace(/\D/g, '')}`;
+
       return {
         ...context.personalInformation,
         firstName,
         lastName,
         email,
-        phoneNumber
+        phoneNumber: phoneE164
       };
     }
   }),


### PR DESCRIPTION
**What:**
Allow machines to retrieve a final state with a phone number that meets E164 format
https://www.twilio.com/docs/glossary/what-e164

**Why:**
This is related to a bug reported before on phone handling
https://app.asana.com/0/1168997577035609/1199565893187287

**How:**
After the refactor at union component https://github.com/debtcollective/packages/pull/143
- Update tests to assert over expected E164 format regardless of any lib used
- Update the method that updates the machine phone value to "transform" to E164 `.replace(/\D/g, '')`

**Note:**
The idea of this PR is to left working code on development. Either way, we are going to look to integrate https://gitlab.com/catamphetamine/react-phone-number-input#with-country-select as it seems to have some built-in solution