### PR TITLE
Union component payment form fix

### DIFF
--- a/packages/union-component/src/components/DonationPaymentForm.tsx
+++ b/packages/union-component/src/components/DonationPaymentForm.tsx
@@ -47,8 +47,7 @@ const DonationPaymentForm: React.FC<Props> = ({
   ] = useState<DonationPaymentProvider>();
   const [cardCompleted, setCardCompleted] = useState(false);
   const [formData, setFormData] = useState({
-    ...defaultValues,
-    phoneNumber: ''
+    ...defaultValues
   });
   const errorMessage = errors?.join(' ');
 

--- a/packages/union-component/src/components/DonationPaymentForm.tsx
+++ b/packages/union-component/src/components/DonationPaymentForm.tsx
@@ -45,6 +45,7 @@ const DonationPaymentForm: React.FC<Props> = ({
     paymentProvider,
     setPaymentProvider
   ] = useState<DonationPaymentProvider>();
+  const [cardCompleted, setCardCompleted] = useState(false);
   const [formData, setFormData] = useState({
     ...defaultValues,
     phoneNumber: ''
@@ -53,10 +54,10 @@ const DonationPaymentForm: React.FC<Props> = ({
 
   useEffect(() => {
     const readyToSubmit = Boolean(
-      paymentProvider && Object.values(formData).every(Boolean)
+      paymentProvider && cardCompleted && Object.values(formData).every(Boolean)
     );
     setIsSubmitDisabled(!readyToSubmit);
-  }, [paymentProvider, formData]);
+  }, [paymentProvider, formData, cardCompleted]);
 
   const handleOnSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.persist();
@@ -105,6 +106,8 @@ const DonationPaymentForm: React.FC<Props> = ({
     if (e.complete) {
       setPaymentProvider(pProvider);
     }
+
+    setCardCompleted(e.complete);
   };
 
   const stripePublicToken = environmentSetup.DC_STRIPE_PUBLIC_TOKEN;


### PR DESCRIPTION
**What:**
Make sure union widget still resilient after issue processing payments

**Why:**
There is an user that reports the issue throughout Chatwoot

**How:**
- Hook "complete" stripe event to submit disabled effect
- Make sure to not bypass `defaultValue` of `phoneNumber` to keep submit disabled coherent
- Remove unnecessary use of RegExp to normalise information after latest third party library migration

**Media**
https://www.loom.com/share/e056a3f0709e4a7c9e6b6ad76f34bd2a
