### PR TITLE
Header colours update

### DIFF
--- a/packages/header-component/src/components/dc-header/styles/base/_variables.scss
+++ b/packages/header-component/src/components/dc-header/styles/base/_variables.scss
@@ -17,6 +17,10 @@ $color-beige: #f9f8f5;
 $color-yellow: #ffed9c;
 $color-green: #24ba9d;
 
+$color-text: #434343;
+$color-text-light: #74736f;
+$color-text-disabled: #52575c;
+
 $column-gap: 15px;
 
 dc-header {

--- a/packages/header-component/src/components/dc-header/styles/base/_variables.scss
+++ b/packages/header-component/src/components/dc-header/styles/base/_variables.scss
@@ -15,6 +15,7 @@ $color-secondary: #ff4630;
 
 $color-beige: #f9f8f5;
 $color-yellow: #ffed9c;
+$color-green-dark: #1e9981;
 $color-green: #24ba9d;
 
 $color-text: #434343;

--- a/packages/header-component/src/components/dc-header/styles/base/_variables.scss
+++ b/packages/header-component/src/components/dc-header/styles/base/_variables.scss
@@ -14,9 +14,11 @@ $color-primary: #fbfbfb;
 $color-secondary: #ff4630;
 
 $color-beige: #f9f8f5;
-$color-yellow: #ffed9c;
 $color-green-dark: #1e9981;
 $color-green: #24ba9d;
+$color-grey: #dadada;
+$color-white: #ffffff;
+$color-yellow: #ffed9c;
 
 $color-text: #434343;
 $color-text-light: #74736f;

--- a/packages/header-component/src/components/dc-header/styles/header/_navbar.scss
+++ b/packages/header-component/src/components/dc-header/styles/header/_navbar.scss
@@ -1,3 +1,4 @@
+@use '../base/variables' as vars;
 @use '../base/mixins' as mixins;
 @use '../base/functions' as fn;
 
@@ -5,13 +6,13 @@ dc-header .navbar {
   -webkit-backface-visibility: hidden;
   align-items: center;
   backface-visibility: hidden;
-  background-color: var(--main-bg-color);
+  background-color: vars.$color-primary;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
   left: 0;
-  padding: 1rem var(--column-gap);
+  padding: 1rem vars.$column-gap;
   position: fixed;
   top: 0;
   width: 100%;

--- a/packages/header-component/src/components/dc-header/styles/link.scss
+++ b/packages/header-component/src/components/dc-header/styles/link.scss
@@ -1,14 +1,18 @@
+@use 'base/variables' as vars;
 @use 'base/typography' as typography;
 
 dc-link {
   cursor: pointer;
 
+  a:active,
+  a:visited,
   a:any-link,
   a:-webkit-any-link {
     color: inherit;
   }
 
   > a {
+    color: inherit;
     align-items: center;
     display: flex;
   }

--- a/packages/header-component/src/components/dc-header/styles/link.scss
+++ b/packages/header-component/src/components/dc-header/styles/link.scss
@@ -15,6 +15,7 @@ dc-link {
     color: inherit;
     align-items: center;
     display: flex;
+    transition: color ease 0.216s;
   }
 }
 

--- a/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
+++ b/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
@@ -127,5 +127,9 @@ dc-menu .menu-nav {
     display: flex;
     flex-direction: column;
     padding: 0 var(--column-gap);
+
+    a:hover {
+      color: vars.$color-green-dark;
+    }
   }
 }

--- a/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
+++ b/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
@@ -8,7 +8,7 @@ dc-menu {
     -webkit-backface-visibility: hidden;
     align-items: flex-start;
     backface-visibility: hidden;
-    background-color: var(--main-bg-color);
+    background-color: vars.$color-white;
     box-shadow: 0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.25);
     box-sizing: border-box;
     display: flex;
@@ -46,7 +46,7 @@ dc-menu {
 
   .menu-section {
     box-sizing: border-box;
-    padding: 0 var(--column-gap);
+    padding: 0 vars.$column-gap;
     width: 100%;
   }
 }
@@ -84,6 +84,8 @@ dc-menu .menu-footer {
 }
 
 dc-menu .menu-nav {
+  $menu-nav-item-border-width: 4px;
+
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -100,18 +102,22 @@ dc-menu .menu-nav {
 
   &-item {
     box-sizing: border-box;
+    border-left: $menu-nav-item-border-width solid transparent;
     color: vars.$color-text;
-    padding: 0 var(--column-gap);
+    padding: 0 vars.$column-gap;
     width: 100%;
+
+    &:hover {
+      border-left-color: vars.$color-grey;
+      background-color: vars.$color-beige;
+    }
   }
 
   &-item-collapsable {
-    $border-width: 4px;
     cursor: pointer;
     @extend .menu-nav-item;
     @extend %custom-details;
-    border-left: $border-width solid transparent;
-    padding: 0 calc(var(--column-gap) - #{$border-width});
+    padding: 0 calc(#{vars.$column-gap} - #{$menu-nav-item-border-width});
 
     &[open] {
       background-color: vars.$color-beige;
@@ -126,7 +132,7 @@ dc-menu .menu-nav {
   &-item-nested {
     display: flex;
     flex-direction: column;
-    padding: 0 var(--column-gap);
+    padding: 0 vars.$column-gap;
 
     a:hover {
       color: vars.$color-green-dark;

--- a/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
+++ b/packages/header-component/src/components/dc-header/styles/navigation/_menu.scss
@@ -100,6 +100,7 @@ dc-menu .menu-nav {
 
   &-item {
     box-sizing: border-box;
+    color: vars.$color-text;
     padding: 0 var(--column-gap);
     width: 100%;
   }


### PR DESCRIPTION
**What:**
Update colours for some elements within navigation.

**Why:**
relates https://app.asana.com/0/1168997577035609/board

**How:**
- Avoid default color from Browser over links in Firefox
- Add `:hover` color transition to menu nav items

**Extras:**
_Migrate some CSS variables to SCSS (CSS variables was the previous approach)_

**Media:**
- https://www.loom.com/share/fb9be51c32b248f5a921811e76b9a9cc
- [Firefox screenshot](https://user-images.githubusercontent.com/1425162/120290315-840fbd00-c2c2-11eb-9b72-f652c54869cd.png)


**Questions:**
- It is intended to have different bg color for navbar and menu? currently `#fbfbfb` vs `white` respectively. CC: @thiagodemellobueno 
- There is no hover color indicated for items within the profile menu