### PR TITLE
feat(header): allow to have authenticated links on menu

### DIFF
--- a/packages/header-component/src/components/dc-header/menu.tsx
+++ b/packages/header-component/src/components/dc-header/menu.tsx
@@ -64,6 +64,27 @@ export class Menu {
             </button>
           </div>
           <menu class="menu-section menu-nav">
+            {this.user
+              ? this.config.authenticatedLinks.map((link) => (
+                  <dc-link
+                    class="menu-nav-item text-lg"
+                    namespace="menu"
+                    role="menuitem"
+                    to={link.url}
+                  >
+                    {link.text}
+                  </dc-link>
+                ))
+              : this.config.guestLinks.map((link) => (
+                  <dc-link
+                    class="menu-nav-item text-lg"
+                    namespace="menu"
+                    role="menuitem"
+                    to={link.url}
+                  >
+                    {link.text}
+                  </dc-link>
+                ))}
             {this.config.rootLinks.map((link) => (
               <dc-link
                 class="menu-nav-item text-lg"

--- a/packages/header-component/src/config.json
+++ b/packages/header-component/src/config.json
@@ -3,7 +3,14 @@
     {
       "type": "MENU_ITEM_LINK",
       "text": "Join the union",
-      "url": "{homepage}/debt-union"
+      "url": "{homepage}/debt-union",
+      "authenticated": false
+    },
+    {
+      "type": "MENU_ITEM_LINK",
+      "text": "Members Hub",
+      "url": "{homepage}/hub",
+      "authenticated": true
     },
     {
       "type": "MENU_ITEM_LINK",

--- a/packages/header-component/src/utils/config.ts
+++ b/packages/header-component/src/utils/config.ts
@@ -69,14 +69,33 @@ export const getSiteMenuConfig = ({ community, user, homepage }) => {
       ...rest,
     }));
 
-  const rootLinks = siteMenu
+  const rootLinks = [];
+  const authenticatedLinks = [];
+  const guestLinks = [];
+
+  siteMenu
     .filter(({ type }) => type === "MENU_ITEM_LINK")
-    .map((item) => {
-      return { ...item, url: interpolateURL(item.url, data) };
+    .forEach((item) => {
+      const itemData = { ...item, url: interpolateURL(item.url, data) };
+
+      // Items without the property set will be always displayed
+      if (!itemData.hasOwnProperty("authenticated")) {
+        rootLinks.push(itemData);
+        return true;
+      }
+
+      if (item.authenticated) {
+        authenticatedLinks.push(itemData);
+        return true;
+      }
+
+      guestLinks.push(itemData);
     });
 
   return {
     expandables,
+    authenticatedLinks,
+    guestLinks,
     rootLinks,
   };
 };


### PR DESCRIPTION
**What:**
Allow to render authenticated links

**Why:**
We need to display "Member Hub" instead "Join the Union" when user logged in

**How:**
Add segmentation on the normalisation layer to have root links, authenticated ones and guest ones

**Media:**
https://www.loom.com/share/fb2afd7085584c30a9f2a587c8da63a4