### PR TITLE
fix: remove top-level await for cjs module

### DIFF
--- a/packages/header-component/src/components.d.ts
+++ b/packages/header-component/src/components.d.ts
@@ -24,6 +24,10 @@ export namespace Components {
           * URL to use after login processed typically full URL from host with the latest "/"
          */
         "returnurl": string;
+        /**
+          * URL to the wordpress menu with the latest "/"
+         */
+        "wordpress": string;
     }
     interface DcLink {
         "namespace": string;
@@ -46,6 +50,7 @@ export namespace Components {
     unread_notifications: number;
     unread_high_priority_notifications: number;
   };
+        "wordpress": string;
     }
     interface DcProfile {
         "community": string;
@@ -121,6 +126,10 @@ declare namespace LocalJSX {
           * URL to use after login processed typically full URL from host with the latest "/"
          */
         "returnurl"?: string;
+        /**
+          * URL to the wordpress menu with the latest "/"
+         */
+        "wordpress"?: string;
     }
     interface DcLink {
         "namespace"?: string;
@@ -149,6 +158,7 @@ declare namespace LocalJSX {
     unread_notifications: number;
     unread_high_priority_notifications: number;
   };
+        "wordpress"?: string;
     }
     interface DcProfile {
         "community"?: string;

--- a/packages/header-component/src/components/dc-header/header.tsx
+++ b/packages/header-component/src/components/dc-header/header.tsx
@@ -76,6 +76,12 @@ export class Header {
   @Prop() community: string = "https://community.debtcollective.org/";
 
   /**
+   * URL to the wordpress menu
+   * with the latest "/"
+   */
+  @Prop() wordpress: string = "https://wordpress-test.debtcollective.org/wp-json/menus/v1/menus/2";
+
+  /**
    * URL to use after login processed typically full URL from host
    * with the latest "/"
    */
@@ -232,6 +238,7 @@ export class Header {
           user={this.user}
           homepage={this.homepage}
           community={this.community}
+          wordpress={this.wordpress}
         />
         <div
           class={`document-cloak ${

--- a/packages/header-component/src/components/dc-header/menu.tsx
+++ b/packages/header-component/src/components/dc-header/menu.tsx
@@ -1,6 +1,6 @@
 import "./link";
 import { Component, h, Event, EventEmitter, Prop, Listen } from "@stencil/core";
-import { getSiteMenuConfig, getSocialLinks } from "../../utils/config";
+import { getSiteMenuConfig, getSocialLinks, interpolateWordpressNav } from "../../utils/config";
 
 @Component({
   assetsDirs: ["assets"],
@@ -15,6 +15,7 @@ export class Menu {
   @Prop() open: boolean;
   @Prop() community: string;
   @Prop() homepage: string;
+  @Prop() wordpress: string;
   @Prop() host: string;
 
   /**
@@ -33,6 +34,7 @@ export class Menu {
   @Event() toggleMenu: EventEmitter<void>;
 
   componentWillRender() {
+    interpolateWordpressNav(this.wordpress);
     this.socialLinks = getSocialLinks();
     this.config = getSiteMenuConfig({
       community: this.community,

--- a/packages/header-component/src/config.json
+++ b/packages/header-component/src/config.json
@@ -1,6 +1,6 @@
-{
-  "wordpress": "https://wordpress-test.debtcollective.org/wp-json/menus/v1/menus/2",
-  
+{ 
+  "siteMenu": [
+  ],
   "userMenu": [
     {
       "type": "USER_MENU_PROFILE_SECTION",

--- a/packages/header-component/src/index.html
+++ b/packages/header-component/src/index.html
@@ -23,6 +23,7 @@
     <dc-header
       community="http://lvh.me:3000/"
       homepage="/"
+      wordpress="https://wordpress-test.debtcollective.org/wp-json/menus/v1/menus/2"
       returnurl="http://lvh.me:3333"
       id="dc-header"
     ></dc-header>

--- a/packages/header-component/src/utils/config.ts
+++ b/packages/header-component/src/utils/config.ts
@@ -2,9 +2,6 @@ import config from "../config.json";
 import { getWordpressNav } from "../services/session";
 
 // pull siteMenu from wordpress site
-
-const { wordpress } = config;
-const wordpressNav = await getWordpressNav(wordpress);
 const interpolateURL = (
   url,
   { user = { username: "" }, community, homepage, returnUrl = "" }
@@ -33,7 +30,8 @@ const interpolateItemsURL = (_items, { user, community, homepage }) => {
   return items;
 };
 
-const interpolateWordpressNav = () => {
+export const interpolateWordpressNav = async (wordpress) => {
+  const wordpressNav = await getWordpressNav(wordpress);
   var wordpressNavConfig = [];
 
   wordpressNav.items.forEach(item => {
@@ -59,7 +57,7 @@ const interpolateWordpressNav = () => {
       wordpressNavConfig.push(row)
     }
   });
-  return wordpressNavConfig;
+  config["siteMenu"] = wordpressNavConfig;
 };
 
 
@@ -95,7 +93,8 @@ export const getUserMenuConfig = ({ community, user, homepage }) => {
  */
 export const getSiteMenuConfig = ({ community, user, homepage }) => {
 
-  const siteMenu = interpolateWordpressNav();
+  const { siteMenu } = config
+    
   const data = { user, community, homepage };
 
   const expandables = siteMenu


### PR DESCRIPTION
**BREAKING CHANGE**
- pulls menu links from wordpress