### PR TITLE
Adds 'notranslate' class to hamburger menu

### DIFF
--- a/packages/header-component/src/components/dc-header/header.tsx
+++ b/packages/header-component/src/components/dc-header/header.tsx
@@ -178,7 +178,7 @@ export class Header {
               class="btn-transparent"
               onClick={this.toggleMenuHandler.bind(this)}
             >
-              <span class="material-icons">menu</span>
+              <span class="material-icons notranslate">menu</span>
             </button>
           </div>
           <div class="l-header-item logo-container navbar-item">


### PR DESCRIPTION
Since the word "menu" represents our icon in google fonts material icons.