### PR TITLE
add mobile consent checkbox to Membership Widget

### DIFF
--- a/packages/union-component/src/MembershipWidget.tsx
+++ b/packages/union-component/src/MembershipWidget.tsx
@@ -174,7 +174,8 @@ const MembershipWidget: React.FC<Props> = ({
             email: personalInformation.email,
             firstName: personalInformation.firstName,
             lastName: personalInformation.lastName,
-            phoneNumber: personalInformation.phoneNumber
+            phoneNumber: personalInformation.phoneNumber,
+            mobileConsent: personalInformation.mobileConsent
           }}
           hasChapterSelection={hasChapterSelection}
           onEditAmount={onEditAmount}

--- a/packages/union-component/src/api/membership.ts
+++ b/packages/union-component/src/api/membership.ts
@@ -46,6 +46,7 @@ export const sendMembershipDonation = async (
       debtInformation,
       chapter: personalInformation.chapter,
       phone_number: personalInformation.phoneNumber,
+      mobileConsent: personalInformation.mobileConsent,
       email: personalInformation.email,
       name: `${personalInformation.firstName} ${personalInformation.lastName}`,
       first_name: personalInformation.firstName,

--- a/packages/union-component/src/components/DonationPaymentForm.tsx
+++ b/packages/union-component/src/components/DonationPaymentForm.tsx
@@ -20,6 +20,7 @@ export interface Props {
     firstName: string;
     lastName: string;
     phoneNumber: string;
+    mobileConsent?: boolean;
     email: string;
   };
   hasChapterSelection?: boolean;
@@ -51,14 +52,18 @@ const DonationPaymentForm: React.FC<Props> = ({
     firstName: string;
     lastName: string;
     phoneNumber: string;
+    mobileConsent?: boolean;
   }>({
     ...defaultValues
   });
   const errorMessage = errors?.join(' ');
 
   useEffect(() => {
+    const { email, firstName, lastName, phoneNumber } = formData;
     const readyToSubmit = Boolean(
-      paymentProvider && cardCompleted && Object.values(formData).every(Boolean)
+      paymentProvider && cardCompleted && Object.values(
+        { email, firstName, lastName, phoneNumber }
+      ).every(Boolean)
     );
     setIsSubmitDisabled(!readyToSubmit);
   }, [paymentProvider, formData, cardCompleted]);
@@ -96,6 +101,12 @@ const DonationPaymentForm: React.FC<Props> = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
     setFormData((state) => ({ ...state, [e.target.name]: e.target.value }));
+  };
+
+  const onChangeInputCheckbox = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData(state => ({ ...state, [e.target.name]: e.target.checked }));
   };
 
   const onChangeInputPhone = (phone: string, isValid: boolean) => {
@@ -162,6 +173,15 @@ const DonationPaymentForm: React.FC<Props> = ({
           required
           title="Contact phone number"
         />
+        {defaultValues.mobileConsent !== undefined && (
+          <DonationWizard.CheckboxWrapper className="form-control">
+            <DonationWizard.Checkbox 
+              name="mobileConsent"
+              onChange={onChangeInputCheckbox}
+            />
+            <label>By entering your phone number and checking this box you are subscribing to receive mobile alerts from The Debt Collective about this and future actions.</label>
+          </DonationWizard.CheckboxWrapper>
+        )}
         {hasChapterSelection ? (
           <DonationDropdown
             id="chapter-dropdown"

--- a/packages/union-component/src/machines/__tests__/membershipMachine.spec.ts
+++ b/packages/union-component/src/machines/__tests__/membershipMachine.spec.ts
@@ -17,6 +17,7 @@ test('goes into process membership state after filling all information', () => {
     lastName: faker.name.lastName(),
     email: faker.internet.email('bot', '', 'debtcollective.org'),
     phoneNumber: faker.phone.phoneNumber('+# ### ### ####'),
+    mobileConsent: false,
     chapter: 'massachusetts'
   };
 

--- a/packages/union-component/src/machines/membershipMachine.ts
+++ b/packages/union-component/src/machines/membershipMachine.ts
@@ -22,6 +22,7 @@ export const membershipMachineContext = {
     lastName: '',
     email: '',
     phoneNumber: '',
+    mobileConsent: false,
     chapter: ''
   },
   debtInformation: {
@@ -66,6 +67,7 @@ export type PersonalData = {
   lastName: string;
   email: string;
   phoneNumber: string;
+  mobileConsent: boolean;
   chapter:
     | 'pennsylvania'
     | 'massachusetts'
@@ -140,7 +142,7 @@ const actions = {
   }),
   updatePayeeInformation: assign<MembershipMachineContext, PersonalNextEvent>({
     personalInformation: (context, event) => {
-      const { firstName, lastName, email, phoneNumber } = event.data;
+      const { firstName, lastName, email, phoneNumber, mobileConsent } = event.data;
       const phoneE164 = `+${phoneNumber.replace(/\D/g, '')}`;
 
       return {
@@ -148,7 +150,8 @@ const actions = {
         firstName,
         lastName,
         email,
-        phoneNumber: phoneE164
+        phoneNumber: phoneE164,
+        mobileConsent
       };
     }
   }),


### PR DESCRIPTION
Adds checkbox for users to consent to texting in Membership Widget.

I was fixing the failing test in the previous PR implementing this and noticed a couple other small things I wanted to fix which are all fixed in this new branch.